### PR TITLE
ISO-251 - Preserve route params when changing locale

### DIFF
--- a/frontend/components/header/LocaleSwitcher/index.tsx
+++ b/frontend/components/header/LocaleSwitcher/index.tsx
@@ -35,7 +35,13 @@ export default function Component() {
 	// C. Handle actions
 
 	const handleLocaleChange = (value: string) => {
-		router.replace(pathname, { locale: value, scroll: true });
+		router.replace(
+			// @ts-expect-error -- TypeScript will validate that only known `params`
+			// are used in combination with a given `pathname`. Since the two will
+			// always match for the current route, we can skip runtime checks.
+			{ params, pathname },
+			{ locale: value, scroll: true },
+		);
 	};
 
 	//


### PR DESCRIPTION
This pull request includes a small but important change to the `LocaleSwitcher` component in the `frontend` directory. The change modifies how the locale is handled when the user switches languages inside a dynamic route.

* [`frontend/components/header/LocaleSwitcher/index.tsx`](diffhunk://#diff-674d58a5f4c38a15598c92cd58be506fd64107ff266adc5ede3e65370f751358L38-R44): Updated the `handleLocaleChange` function to use `params` and `pathname` together, with a TypeScript comment to skip runtime checks.