### PR TITLE
Digital 263 - Feat: Selecionar Horario em Linha

### DIFF
--- a/frontend/components/common/TimetableSchedules/index.tsx
+++ b/frontend/components/common/TimetableSchedules/index.tsx
@@ -6,6 +6,7 @@ import type { Minute } from '@/types/timetables.types';
 import { useTranslations } from 'next-intl';
 
 import styles from './styles.module.css';
+import { useLinesDetailContext } from '@/contexts/LinesDetail.context';
 
 /* * */
 
@@ -24,6 +25,7 @@ export default function TimetableSchedules({ selectedExceptionIds, setSelectedEx
 	// A. Setup variables
 
 	const t = useTranslations('common.TimetableSchedules');
+	const linesDetailContext = useLinesDetailContext();
 
 	//
 	// B. Render components
@@ -43,6 +45,8 @@ export default function TimetableSchedules({ selectedExceptionIds, setSelectedEx
 							minuteData={minuteData}
 							selectedExceptionIds={selectedExceptionIds}
 							setSelectedExceptionIds={setSelectedExceptionIds}
+							isHighlighted={Boolean(linesDetailContext.data.highlighted_trip_ids && minuteData.trip_ids.some(tripId => linesDetailContext.data.highlighted_trip_ids?.includes(tripId)))}
+							onClick={() => linesDetailContext.actions.setHighlightedTripIds(minuteData.trip_ids)}
 						/>
 					))}
 				</div>
@@ -59,11 +63,13 @@ interface TimetableSchedulesMinuteProps {
 	minuteData: Minute
 	selectedExceptionIds: string[]
 	setSelectedExceptionIds: (values: string[]) => void
+	isHighlighted: boolean
+	onClick?: () => void
 }
 
 /* * */
 
-function TimetableSchedulesMinute({ minuteData, selectedExceptionIds, setSelectedExceptionIds }: TimetableSchedulesMinuteProps) {
+function TimetableSchedulesMinute({ minuteData, selectedExceptionIds, setSelectedExceptionIds, isHighlighted, onClick }: TimetableSchedulesMinuteProps) {
 	//
 
 	//
@@ -88,9 +94,10 @@ function TimetableSchedulesMinute({ minuteData, selectedExceptionIds, setSelecte
 	return (
 		<p
 			key={minuteData.minute_value}
-			className={`${styles.minute} ${minuteData.exception_ids.length > 0 && styles.withException} ${isSelected && styles.isSelected} ${!isSelected && selectedExceptionIds.length > 0 && styles.isOthersSelected}`}
+			className={`${styles.minute} ${minuteData.exception_ids.length > 0 && styles.withException} ${isSelected && styles.isSelected} ${!isSelected && selectedExceptionIds.length > 0 && styles.isOthersSelected} ${isHighlighted && styles.isHighlighted}`}
 			onMouseOut={handleMouseOutException}
 			onMouseOver={handleMouseOverException}
+			onClick={onClick}
 		>
 			{minuteData.minute_label}
 			{minuteData.exception_ids.length > 0 && minuteData.exception_ids.map(exceptionId => (

--- a/frontend/components/common/TimetableSchedules/styles.module.css
+++ b/frontend/components/common/TimetableSchedules/styles.module.css
@@ -89,6 +89,14 @@
 	line-height: 1;
 	padding: 0 6px;
 	font-weight: var(--font-weight-semibold);
+	cursor: pointer;
+	transition: all 0.1s ease-in-out;
+
+	&:hover {
+		scale: 1.05;
+		translate: 0 -2px;
+		color: var(--color-system-text-200);
+	}
 }
 
 .column:first-child .minute {
@@ -113,6 +121,13 @@
 
 .minute.isOthersSelected {
 	color: var(--color-system-text-400);
+}
+
+.minute.isHighlighted {
+	margin: 2px;
+	color: light-dark(var(--color-system-text-100), var(--color-brand));
+	background-color: light-dark(var(--color-brand), var(--color-system-background-100));
+	border-radius: 100%;
 }
 
 /* * */

--- a/frontend/contexts/LinesDetail.context.tsx
+++ b/frontend/contexts/LinesDetail.context.tsx
@@ -21,6 +21,7 @@ interface LinesDetailContextState {
 	actions: {
 		setActivePattern: (patternGroupId: string) => void
 		setActiveWaypoint: (stopId: string, stopSequence: number,) => void
+		setHighlightedTripIds: (tripIds: string[]) => void
 	}
 	data: {
 		active_alerts: SimplifiedAlert[] | undefined
@@ -33,6 +34,7 @@ interface LinesDetailContextState {
 		routes: Route[]
 		service_metrics: ServiceMetrics[]
 		valid_patterns: Pattern[] | undefined
+		highlighted_trip_ids: null | string[]
 	}
 	filters: {
 		active_pattern_id: null | string
@@ -83,7 +85,7 @@ export const LinesDetailContextProvider = ({ children, lineId }) => {
 	const [dataActivePatternState, setDataActivePatternState] = useState<LinesDetailContextState['data']['active_pattern']>(null);
 	const [dataActiveShapeState, setDataActiveShapeState] = useState<LinesDetailContextState['data']['active_shape']>(null);
 	const [dataActiveWaypointState, setDataActiveWaypointState] = useState<LinesDetailContextState['data']['active_waypoint']>(null);
-
+	const [dataHighlightedTripIdsState, setDataHighlightedTripIdsState] = useState<LinesDetailContextState['data']['highlighted_trip_ids']>([]);
 	const [filterActivePatternIdState, setFilterActivePatternIdState] = useQueryState('active_pattern_id');
 	const [filterActiveWaypointStopIdState, setFilterActiveWaypointStopIdState] = useQueryState('active_waypoint_stop_id');
 	const [filterActiveWaypointStopSequenceState, setFilterActiveWaypointStopSequenceState] = useQueryState('active_waypoint_stop_sequence');
@@ -332,6 +334,16 @@ export const LinesDetailContextProvider = ({ children, lineId }) => {
 		}
 	};
 
+	/**
+	 * Set the highlighted trip ids.
+	 * @param tripIds
+	 * @returns
+	 */
+	const setHighlightedTripIds = (tripIds: string[]) => {
+		if (tripIds === dataHighlightedTripIdsState) setDataHighlightedTripIdsState(null);
+		else setDataHighlightedTripIdsState(tripIds);
+	};
+
 	//
 	// E. Define context value
 
@@ -339,6 +351,7 @@ export const LinesDetailContextProvider = ({ children, lineId }) => {
 		actions: {
 			setActivePattern,
 			setActiveWaypoint,
+			setHighlightedTripIds,
 		},
 		data: {
 			active_alerts: dataActiveAlertsState,
@@ -351,6 +364,7 @@ export const LinesDetailContextProvider = ({ children, lineId }) => {
 			routes: dataRoutesState,
 			service_metrics: dataServiceMetricsState,
 			valid_patterns: dataValidPatternsState,
+			highlighted_trip_ids: dataHighlightedTripIdsState,
 		},
 		filters: {
 			active_pattern_id: filterActivePatternIdState,

--- a/frontend/types/timetables.types.ts
+++ b/frontend/types/timetables.types.ts
@@ -19,6 +19,7 @@ export interface Minute {
 	exception_ids: string[]
 	minute_label: string
 	minute_value: number
+	trip_ids: string[]
 }
 
 /* * */

--- a/frontend/utils/createTimetable.ts
+++ b/frontend/utils/createTimetable.ts
@@ -51,14 +51,14 @@ export default function createTimetable(primaryPatternGroup: Pattern, secondaryP
 			// Find or create the hour entry in the timetable
 			let hourEntry = timetableResult.hours.find(h => h.hour_value === hourValue);
 			if (!hourEntry) {
-				hourEntry = { hour_label: hour24, hour_value: hourValue, minutes: [] };
+				hourEntry = { hour_label: hour24, hour_value: hourValue, minutes: []};
 				timetableResult.hours.push(hourEntry);
 			}
 			// Find or create the minute entry in the timetable
 			// Since we're processing the primary Pattern, ensure that the minute entry does not have any exceptions.
 			const minuteEntry = hourEntry.minutes.find(m => m.minute_value === minuteValue && m.exception_ids === undefined);
 			if (!minuteEntry) {
-				hourEntry.minutes.push({ exception_ids: [], minute_label: minute24, minute_value: minuteValue });
+				hourEntry.minutes.push({ exception_ids: [], minute_label: minute24, minute_value: minuteValue, trip_ids: trip.trip_ids });
 			}
 		});
 	});
@@ -103,7 +103,7 @@ export default function createTimetable(primaryPatternGroup: Pattern, secondaryP
 				}
 				// Create a new minute entry if it doesn't exist yet
 				if (!minuteEntry) {
-					hourEntry.minutes.push({ exception_ids: [existingException.exception_id], minute_label: minute24, minute_value: minuteValue });
+					hourEntry.minutes.push({ exception_ids: [existingException.exception_id], minute_label: minute24, minute_value: minuteValue, trip_ids: trip.trip_ids });
 				}
 				// If the minute entry already exists, add the exception ID to it
 				else {


### PR DESCRIPTION
This pull request introduces several changes to the `TimetableSchedules` component and its related context and utility functions. The main focus is on adding functionality to highlight specific trips in the timetable and improving the user interface with new styles.

Changes to `TimetableSchedules` component:

* Added `useLinesDetailContext` to access context data and actions.
* Introduced `isHighlighted` and `onClick` props to `TimetableSchedulesMinute` component to handle highlighting of trips. [[1]](diffhunk://#diff-b305dfacff463db6e6cdc018fdf762c984dc18d2934889cf1e4a4a323fd7a8dcR48-R49) [[2]](diffhunk://#diff-b305dfacff463db6e6cdc018fdf762c984dc18d2934889cf1e4a4a323fd7a8dcR66-R72)
* Updated the rendering logic to apply the `isHighlighted` class and handle click events.

Updates to context:

* Added `setHighlightedTripIds` action and `highlighted_trip_ids` data to `LinesDetailContextState`. [[1]](diffhunk://#diff-9e6b4b44eaa37a5fbc8c617dd79ff85927363d368c11890d96aa19542431affdR24) [[2]](diffhunk://#diff-9e6b4b44eaa37a5fbc8c617dd79ff85927363d368c11890d96aa19542431affdR37)
* Implemented the `setHighlightedTripIds` function in `LinesDetailContextProvider`.

Styling improvements:

* Added hover effects and transitions to the `minute` class in `styles.module.css`.
* Introduced `isHighlighted` class to style highlighted trips.

Other changes:

* Added `trip_ids` to the `Minute` interface in `timetables.types.ts`.
* Updated `createTimetable` utility function to include `trip_ids` in minute entries. [[1]](diffhunk://#diff-1fd08f3bff041a6a11cd3b1ed28a3b3e477bce72dc8c29e16c5e7f079f7674f7L61-R61) [[2]](diffhunk://#diff-1fd08f3bff041a6a11cd3b1ed28a3b3e477bce72dc8c29e16c5e7f079f7674f7L106-R106)