### PR TITLE
Fixed the date formatting

### DIFF
--- a/frontend/components/news/NewsDetailHeader/index.tsx
+++ b/frontend/components/news/NewsDetailHeader/index.tsx
@@ -30,10 +30,16 @@ export function NewsDetailHeader({ newsData }) {
 		);
 	}
 
+	//
+	// C. Transform Data
+	const formattedDate = newsData?.publish_date?.endsWith('Z')
+		? newsData.publish_date
+		: `${newsData.publish_date}Z`;
+
 	return (
 		<Section withBottomDivider withGap withPadding>
 			<h1 className={styles.title}>{newsData?.title || 'title'}</h1>
-			<p className={styles.publishDate}>{t('publish_date', { value: newsData?.date })}</p>
+			<p className={styles.publishDate}>{t('publish_date', { value: new Date(formattedDate) })}</p>
 		</Section>
 	);
 

--- a/frontend/components/news/NewsDetailHeader/index.tsx
+++ b/frontend/components/news/NewsDetailHeader/index.tsx
@@ -4,6 +4,7 @@
 
 import { Section } from '@/components/layout/Section';
 import { Skeleton } from '@mantine/core';
+import { DateTime } from 'luxon';
 import { useTranslations } from 'next-intl';
 
 import styles from './styles.module.css';
@@ -19,7 +20,12 @@ export function NewsDetailHeader({ newsData }) {
 	const t = useTranslations('news.SinglePageHeader');
 
 	//
-	// B. Render Components
+	// B. Transform data
+
+	const formattedDate = DateTime.fromISO(newsData?.publish_date).toJSDate();
+
+	//
+	// C. Render Components
 
 	if (!newsData) {
 		return (
@@ -30,16 +36,10 @@ export function NewsDetailHeader({ newsData }) {
 		);
 	}
 
-	//
-	// C. Transform Data
-	const formattedDate = newsData?.publish_date?.endsWith('Z')
-		? newsData.publish_date
-		: `${newsData.publish_date}Z`;
-
 	return (
 		<Section withBottomDivider withGap withPadding>
 			<h1 className={styles.title}>{newsData?.title || 'title'}</h1>
-			<p className={styles.publishDate}>{t('publish_date', { value: new Date(formattedDate) })}</p>
+			<p className={styles.publishDate}>{t('publish_date', { value: formattedDate })}</p>
 		</Section>
 	);
 


### PR DESCRIPTION
Added a function to fix the timezone, this was the problem as the date couldn't be parsed because of the missing timezone therefore giving a default value of today.
Modified the display of newsData.publishDate to reflect this needed parsing.

In the future the news could be saved with this timezone already incorporated thus the function can be removed.
Changes made on NewsDetailsHeader.