### PR TITLE
Added Dynamic page links to news page

### DIFF
--- a/frontend/app/(views)/(website)/lines/[line_id]/page.tsx
+++ b/frontend/app/(views)/(website)/lines/[line_id]/page.tsx
@@ -5,6 +5,36 @@ import { LinesDetailContextProvider } from '@/contexts/LinesDetail.context';
 
 /* * */
 
+// export async function generateMetadata({ params }) {
+// 	const data = await params;
+// 	try {
+// 		const id = await data.news_id;
+// 		console.log('meh', id);
+
+// 		const newsData = await fetch(`${process.env.NEXT_PUBLIC_URL}/api/news/${id}`).then(res => res.json());
+
+// 		return {
+// 			description: newsData.title,
+// 			openGraph: {
+// 				description: newsData.title,
+// 				title: newsData.title,
+// 			},
+// 			title: newsData.title,
+// 		};
+// 	}
+// 	catch (error) {
+// 		console.error('There was an error loading the page metadata: ', error);
+// 		return {
+// 			description: 'TESTE',
+// 			openGraph: {
+// 				description: 'TESTE',
+// 				title: 'CMetropolitana - TESTE',
+// 			},
+// 			title: 'TESTE',
+// 		};
+// 	}
+// }
+
 export default async function Page({ params }) {
 	//
 

--- a/frontend/app/(views)/(website)/lines/[line_id]/page.tsx
+++ b/frontend/app/(views)/(website)/lines/[line_id]/page.tsx
@@ -5,35 +5,33 @@ import { LinesDetailContextProvider } from '@/contexts/LinesDetail.context';
 
 /* * */
 
-// export async function generateMetadata({ params }) {
-// 	const data = await params;
-// 	try {
-// 		const id = await data.news_id;
-// 		console.log('meh', id);
+export async function generateMetadata({ params }) {
+	const data = await params;
+	try {
+		const id = await data.line_id;
+		const newsData = await fetch(`https://api.carrismetropolitana.pt/lines/${id}`).then(res => res.json());
 
-// 		const newsData = await fetch(`${process.env.NEXT_PUBLIC_URL}/api/news/${id}`).then(res => res.json());
-
-// 		return {
-// 			description: newsData.title,
-// 			openGraph: {
-// 				description: newsData.title,
-// 				title: newsData.title,
-// 			},
-// 			title: newsData.title,
-// 		};
-// 	}
-// 	catch (error) {
-// 		console.error('There was an error loading the page metadata: ', error);
-// 		return {
-// 			description: 'TESTE',
-// 			openGraph: {
-// 				description: 'TESTE',
-// 				title: 'CMetropolitana - TESTE',
-// 			},
-// 			title: 'TESTE',
-// 		};
-// 	}
-// }
+		return {
+			description: newsData.long_name,
+			openGraph: {
+				description: newsData.localities,
+				title: newsData.long_name,
+			},
+			title: newsData.long_name,
+		};
+	}
+	catch (error) {
+		console.error('There was an error loading the page metadata: ', error);
+		return {
+			description: 'Linhas',
+			openGraph: {
+				description: 'Linhas',
+				title: 'CMetropolitana - Linhas',
+			},
+			title: 'Linhas',
+		};
+	}
+}
 
 export default async function Page({ params }) {
 	//

--- a/frontend/app/(views)/(website)/lines/page.tsx
+++ b/frontend/app/(views)/(website)/lines/page.tsx
@@ -1,6 +1,7 @@
 /* * */
 
 import { LinesList } from '@/components/lines/LinesList';
+import { Metadata } from 'next';
 
 /* * */
 
@@ -9,3 +10,12 @@ export default function Page() {
 		<LinesList />
 	);
 }
+
+export const metadata: Metadata = {
+	description: 'Todas as linhas da carris metropolitana',
+	openGraph: {
+		description: 'Linhas',
+		title: 'CMetropolitana - Linhas',
+	},
+	title: 'CMetropolitana - Linhas',
+};

--- a/frontend/app/(views)/(website)/news/[news_id]/page.tsx
+++ b/frontend/app/(views)/(website)/news/[news_id]/page.tsx
@@ -8,8 +8,6 @@ export async function generateMetadata({ params }) {
 	const data = await params;
 	try {
 		const id = await data.news_id;
-		console.log('meh', id);
-
 		const newsData = await fetch(`${process.env.NEXT_PUBLIC_URL}/api/news/${id}`).then(res => res.json());
 
 		return {

--- a/frontend/app/(views)/(website)/news/[news_id]/page.tsx
+++ b/frontend/app/(views)/(website)/news/[news_id]/page.tsx
@@ -4,6 +4,36 @@ import { NewsDetail } from '@/components/news/NewsDetail';
 
 /* * */
 
+export async function generateMetadata({ params }) {
+	const data = await params;
+	try {
+		const id = await data.news_id;
+		console.log('meh', id);
+
+		const newsData = await fetch(`${process.env.NEXT_PUBLIC_URL}/api/news/${id}`).then(res => res.json());
+
+		return {
+			description: newsData.title,
+			openGraph: {
+				description: newsData.title,
+				title: newsData.title,
+			},
+			title: newsData.title,
+		};
+	}
+	catch (error) {
+		console.error('There was an error loading the page metadata: ', error);
+		return {
+			description: 'TESTE',
+			openGraph: {
+				description: 'TESTE',
+				title: 'CMetropolitana - TESTE',
+			},
+			title: 'TESTE',
+		};
+	}
+}
+
 export default async function Page({ params }) {
 	const { news_id } = await params;
 	return <NewsDetail newsId={news_id} />;

--- a/frontend/app/(views)/(website)/news/[news_id]/page.tsx
+++ b/frontend/app/(views)/(website)/news/[news_id]/page.tsx
@@ -24,12 +24,12 @@ export async function generateMetadata({ params }) {
 	catch (error) {
 		console.error('There was an error loading the page metadata: ', error);
 		return {
-			description: 'TESTE',
+			description: 'Notícias',
 			openGraph: {
-				description: 'TESTE',
-				title: 'CMetropolitana - TESTE',
+				description: 'Notícias',
+				title: 'CMetropolitana - Notícias',
 			},
-			title: 'TESTE',
+			title: 'Notícias',
 		};
 	}
 }

--- a/frontend/app/(views)/(website)/news/page.tsx
+++ b/frontend/app/(views)/(website)/news/page.tsx
@@ -7,3 +7,11 @@ import { NewsList } from '@/components/news/NewsList';
 export default function Page() {
 	return <NewsList />;
 }
+export const metadata: Metadata = {
+	description: 'Todas as noticias da carris metropolitana',
+	openGraph: {
+		description: 'Notícias',
+		title: 'CMetropolitana - Notícias',
+	},
+	title: 'CMetropolitana - Notícias',
+};

--- a/frontend/app/(views)/(website)/news/page.tsx
+++ b/frontend/app/(views)/(website)/news/page.tsx
@@ -1,12 +1,14 @@
 /* * */
 
 import { NewsList } from '@/components/news/NewsList';
+import { Metadata } from 'next';
 
 /* * */
 
 export default function Page() {
 	return <NewsList />;
 }
+
 export const metadata: Metadata = {
 	description: 'Todas as noticias da carris metropolitana',
 	openGraph: {

--- a/frontend/app/(views)/(website)/stops/[stop_id]/page.tsx
+++ b/frontend/app/(views)/(website)/stops/[stop_id]/page.tsx
@@ -5,35 +5,33 @@ import { StopsDetailContextProvider } from '@/contexts/StopsDetail.context';
 
 /* * */
 
-// export async function generateMetadata({ params }) {
-// 	const data = await params;
-// 	try {
-// 		const id = await data.news_id;
-// 		console.log('meh', id);
-
-// 		const newsData = await fetch(`${process.env.NEXT_PUBLIC_URL}/api/news/${id}`).then(res => res.json());
-
-// 		return {
-// 			description: newsData.title,
-// 			openGraph: {
-// 				description: newsData.title,
-// 				title: newsData.title,
-// 			},
-// 			title: newsData.title,
-// 		};
-// 	}
-// 	catch (error) {
-// 		console.error('There was an error loading the page metadata: ', error);
-// 		return {
-// 			description: 'TESTE',
-// 			openGraph: {
-// 				description: 'TESTE',
-// 				title: 'CMetropolitana - TESTE',
-// 			},
-// 			title: 'TESTE',
-// 		};
-// 	}
-// }
+export async function generateMetadata({ params }) {
+	const data = await params;
+	try {
+		const id = await data.stop_id;
+		const stopData = await fetch(`https://api.carrismetropolitana.pt/stops/${id}`).then(res => res.json());
+		const stopAddress = stopData.name + ', ' + stopData.municipality_name;
+		return {
+			description: stopAddress,
+			openGraph: {
+				description: stopAddress,
+				title: stopData.short_name,
+			},
+			title: stopData.short_name,
+		};
+	}
+	catch (error) {
+		console.error('There was an error loading the page metadata: ', error);
+		return {
+			description: 'Paragens',
+			openGraph: {
+				description: 'Paragens',
+				title: 'CMetropolitana - Paragens',
+			},
+			title: 'Paragens',
+		};
+	}
+}
 
 export default async function Page({ params }) {
 	//

--- a/frontend/app/(views)/(website)/stops/[stop_id]/page.tsx
+++ b/frontend/app/(views)/(website)/stops/[stop_id]/page.tsx
@@ -5,6 +5,36 @@ import { StopsDetailContextProvider } from '@/contexts/StopsDetail.context';
 
 /* * */
 
+// export async function generateMetadata({ params }) {
+// 	const data = await params;
+// 	try {
+// 		const id = await data.news_id;
+// 		console.log('meh', id);
+
+// 		const newsData = await fetch(`${process.env.NEXT_PUBLIC_URL}/api/news/${id}`).then(res => res.json());
+
+// 		return {
+// 			description: newsData.title,
+// 			openGraph: {
+// 				description: newsData.title,
+// 				title: newsData.title,
+// 			},
+// 			title: newsData.title,
+// 		};
+// 	}
+// 	catch (error) {
+// 		console.error('There was an error loading the page metadata: ', error);
+// 		return {
+// 			description: 'TESTE',
+// 			openGraph: {
+// 				description: 'TESTE',
+// 				title: 'CMetropolitana - TESTE',
+// 			},
+// 			title: 'TESTE',
+// 		};
+// 	}
+// }
+
 export default async function Page({ params }) {
 	//
 

--- a/frontend/app/(views)/(website)/stops/page.tsx
+++ b/frontend/app/(views)/(website)/stops/page.tsx
@@ -1,6 +1,7 @@
 /* * */
 
 import { StopsList } from '@/components/stops/StopsList';
+import { Metadata } from 'next';
 
 /* * */
 
@@ -9,3 +10,12 @@ export default function Page() {
 		<StopsList />
 	);
 }
+
+export const metadata: Metadata = {
+	description: 'Todas as paragens da carris metropolitana',
+	openGraph: {
+		description: 'Paragens',
+		title: 'CMetropolitana - Paragens',
+	},
+	title: 'CMetropolitana - Paragens',
+};

--- a/frontend/components/news/NewsDetail/index.tsx
+++ b/frontend/components/news/NewsDetail/index.tsx
@@ -9,6 +9,7 @@ import { NewsDetailContent } from '@/components/news/NewsDetailContent';
 import { NewsDetailHeader } from '@/components/news/NewsDetailHeader';
 import { NewsDetailSidebar } from '@/components/news/NewsDetailSidebar';
 import { NewsData } from '@/types/news.types';
+import { Metadata } from 'next';
 import { useEffect, useState } from 'react';
 import useSWR from 'swr';
 


### PR DESCRIPTION
Added generateMetaData() on page.tsx(news).
This functions generates the page metadata it is a core function off Next.js, it is only available on server components.
Replication of the behaviour to pages Stops and Lines are planned