### PR TITLE
Fix alert carousel link target default to _self

### DIFF
--- a/apps/frontend/src/components/common/AlertsCarousel/index.tsx
+++ b/apps/frontend/src/components/common/AlertsCarousel/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 /* * */
 
-export function AlertsCarousel({ alerts, target = '_blank' }: Props) {
+export function AlertsCarousel({ alerts, target = '_self' }: Props) {
 	//
 
 	const carouselSlides = alerts?.map(slideItem => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,6 @@
 			"resolved": "https://registry.npmjs.org/@payloadcms/next/-/next-3.67.0.tgz",
 			"integrity": "sha512-CrrqRn5t+HIsCNmt/Jkg7l3fDA/4MIrx7ZR7Q/LHKoEFo2qVb0tG0sFP48J/nFFjxQv7Mn4PhKeb7U6gxgG9JQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@dnd-kit/core": "6.0.8",
 				"@payloadcms/graphql": "3.67.0",
@@ -307,7 +306,6 @@
 			"resolved": "https://registry.npmjs.org/payload/-/payload-3.67.0.tgz",
 			"integrity": "sha512-ymMVQZb1v0OpkqiQAUw/AumKe2B5OXyBPnzUSjuW0AoVoBV5SSarEyo9m+csEBkKeus4m6MlZbD59x0KjTR49w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@next/env": "^15.1.5",
 				"@payloadcms/translations": "3.67.0",
@@ -870,7 +868,6 @@
 			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.943.0.tgz",
 			"integrity": "sha512-UOX8/1mmNaRmEkxoIVP2+gxd5joPJqz+fygRqlIXON1cETLGoctinMwQs7qU8g8hghm76TU2G6ZV6sLH8cySMw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha1-browser": "5.2.0",
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -1840,7 +1837,6 @@
 			"integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
 			}
@@ -2068,7 +2064,6 @@
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2160,7 +2155,6 @@
 			"integrity": "sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.34.1",
 				"@typescript-eslint/types": "8.34.1",
@@ -2244,7 +2238,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2268,7 +2261,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2343,7 +2335,6 @@
 			"resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.8.tgz",
 			"integrity": "sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@dnd-kit/accessibility": "^3.0.0",
 				"@dnd-kit/utilities": "^3.2.1",
@@ -3204,7 +3195,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"body-scroll-lock": "4.0.0-beta.0",
 				"focus-trap": "7.5.4",
@@ -3226,7 +3216,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -4338,7 +4327,6 @@
 			"resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.9.tgz",
 			"integrity": "sha512-ivj0Crn5N521cI2eWZBsBGckg0ZYRqfOJz5vbbvYmfj65bp0EdsyqZuOxXzIcn2aUScQhskfvzyhV5XIUv81PQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@floating-ui/react": "^0.27.16",
 				"clsx": "^2.1.1",
@@ -4374,7 +4362,6 @@
 			"resolved": "https://registry.npmjs.org/@mantine/form/-/form-8.3.9.tgz",
 			"integrity": "sha512-G7eCo5TEWGcsWHrNGwp/o1yPcCYbaMdLq6SClN+wMhAA+qaEO1ZHf9mX8fSOX78nkaoyIrZHGOhbVXcZ7hmVrQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"klona": "^2.0.6"
@@ -4388,7 +4375,6 @@
 			"resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.9.tgz",
 			"integrity": "sha512-Dfz7W0+K1cq4Gb1WFQCZn8tsMXkLH6MV409wZR/ToqsxdNDUMJ/xxbfnwEXWEZjXNJd1wDETHgc+cZG2lTe3Xw==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"react": "^18.x || ^19.x"
 			}
@@ -5765,7 +5751,6 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
 			"integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8138,7 +8123,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
 			"integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -8397,7 +8381,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
 			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -9326,8 +9309,7 @@
 			"version": "1.11.19",
 			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
 			"integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -9461,6 +9443,7 @@
 			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
 			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
+			"peer": true,
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
 			}
@@ -9527,8 +9510,7 @@
 			"version": "8.6.0",
 			"resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
 			"integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/embla-carousel-autoplay": {
 			"version": "8.6.0",
@@ -9544,7 +9526,6 @@
 			"resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
 			"integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"embla-carousel": "8.6.0",
 				"embla-carousel-reactive-utils": "8.6.0"
@@ -9730,7 +9711,6 @@
 			"integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -10480,7 +10460,6 @@
 			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
 			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"gaxios": "^7.0.0",
 				"google-logging-utils": "^1.0.0",
@@ -10832,7 +10811,6 @@
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
 			"integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
@@ -11366,6 +11344,7 @@
 			"resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
 			"integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "GitHub Sponsors ❤",
 				"url": "https://github.com/sponsors/dmonad"
@@ -11518,7 +11497,6 @@
 			"integrity": "sha512-uuPNLJkKN8NXAlZlQ6kmUF9qO+T6Kyd7oV4+/7yy8Jz6+MZNyhPq8EdLpdfnPVzUC8qSf1b4j1azKaGnFsjmsw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"acorn": "^8.5.0",
 				"eslint-visitor-keys": "^3.0.0",
@@ -11739,6 +11717,7 @@
 			"resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
 			"integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"isomorphic.js": "^0.2.4"
 			},
@@ -11981,6 +11960,7 @@
 			"resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
 			"integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -12956,7 +12936,6 @@
 			"resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
 			"integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@next/env": "15.5.7",
 				"@swc/helpers": "0.5.15",
@@ -13635,7 +13614,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -13827,7 +13805,6 @@
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -13859,6 +13836,7 @@
 			"integrity": "sha512-Mn8KJ45HNNG6JBpBizXcyf6LqY/qyqetGcou/nprDnFwBFBLGj0j/sNKV2lj2KMOVOwdXu14aEzqJv8CIV6e8g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"postcss": "^8.4.20"
 			}
@@ -14097,7 +14075,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
 			"integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -14132,7 +14109,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
 			"integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -14243,7 +14219,6 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
 			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -14446,7 +14421,6 @@
 			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.5.1.tgz",
 			"integrity": "sha512-+v+HJojK7gnEgG6h+b2u7k8HH7FhyFUzAc4+cPrsjL4Otdgqr/ecXzAnHciqlzV1ko064eNcsdzrYOM78kankA==",
 			"license": "MIT",
-			"peer": true,
 			"workspaces": [
 				"www"
 			],
@@ -14476,8 +14450,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -14775,8 +14748,7 @@
 			"version": "0.25.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
 			"integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/scmp": {
 			"version": "2.1.0",
@@ -15377,7 +15349,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@csstools/css-parser-algorithms": "^3.0.5",
 				"@csstools/css-tokenizer": "^3.0.4",
@@ -16245,7 +16216,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -16951,7 +16921,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
 			"integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}


### PR DESCRIPTION
## Changes

- Changed default `target` prop in `AlertsCarousel` component from `'_blank'` to `'_self'`
- This ensures alert links open in the same tab by default instead of opening new tabs

## Context

The alert carousel was opening links in new tabs by default, which may not be the desired behavior. This change makes links open in the same tab unless explicitly specified otherwise.

## Files Changed

- `apps/frontend/src/components/common/AlertsCarousel/index.tsx`
- `package-lock.json` (lockfile updates)