### PR TITLE
Feat: Add Articles collection under backoffice for new CICM project

### DIFF
--- a/apps/backoffice/payload-types.ts
+++ b/apps/backoffice/payload-types.ts
@@ -67,6 +67,7 @@ export interface Config {
   };
   blocks: {};
   collections: {
+    articles: Article;
     'case-studies': CaseStudy;
     'knowledge-base': KnowledgeBase;
     media: Media;
@@ -81,6 +82,7 @@ export interface Config {
   };
   collectionsJoins: {};
   collectionsSelect: {
+    articles: ArticlesSelect<false> | ArticlesSelect<true>;
     'case-studies': CaseStudiesSelect<false> | CaseStudiesSelect<true>;
     'knowledge-base': KnowledgeBaseSelect<false> | KnowledgeBaseSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
@@ -134,6 +136,78 @@ export interface UserAuthOperations {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "articles".
+ */
+export interface Article {
+  id: string;
+  title: string;
+  /**
+   * URL única para este artigo. Será gerada automaticamente do título se deixado em branco.
+   */
+  slug: string;
+  /**
+   * Resumo curto do artigo que aparece na listagem e no início do artigo.
+   */
+  description: string;
+  type: 'tecnologia' | 'operacao' | 'sustentabilidade' | 'comunicacao';
+  /**
+   * Tempo estimado de leitura em minutos.
+   */
+  readTime: number;
+  heroImage: string | Media;
+  /**
+   * Legenda que aparece sobre a imagem de destaque.
+   */
+  heroImageCaption?: string | null;
+  /**
+   * Conteúdo do artigo em formato Markdown. Suporta títulos (##), listas, links, citações e muito mais.
+   */
+  content: string;
+  author: {
+    picture?: (string | null) | Media;
+    name: string;
+    role: string;
+    /**
+     * Breve descrição sobre o autor.
+     */
+    bio?: string | null;
+    social?: {
+      linkedin?: string | null;
+      twitter?: string | null;
+      email?: string | null;
+    };
+  };
+  publishDate: string;
+  status: 'draft' | 'published';
+  seo?: {
+    metaTitle?: string | null;
+    metaDescription?: string | null;
+    ogImage?: (string | null) | Media;
+  };
+  publishedAt: string;
+  updatedAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media".
+ */
+export interface Media {
+  id: string;
+  alt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "case-studies".
  */
 export interface CaseStudy {
@@ -178,25 +252,6 @@ export interface KnowledgeBase {
   authors?: (string | null) | User;
   publishedAt: string;
   updatedAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "media".
- */
-export interface Media {
-  id: string;
-  alt?: string | null;
-  updatedAt: string;
-  createdAt: string;
-  url?: string | null;
-  thumbnailURL?: string | null;
-  filename?: string | null;
-  mimeType?: string | null;
-  filesize?: number | null;
-  width?: number | null;
-  height?: number | null;
-  focalX?: number | null;
-  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -322,6 +377,10 @@ export interface PayloadLockedDocument {
   id: string;
   document?:
     | ({
+        relationTo: 'articles';
+        value: string | Article;
+      } | null)
+    | ({
         relationTo: 'case-studies';
         value: string | CaseStudy;
       } | null)
@@ -390,6 +449,46 @@ export interface PayloadMigration {
   batch?: number | null;
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "articles_select".
+ */
+export interface ArticlesSelect<T extends boolean = true> {
+  title?: T;
+  slug?: T;
+  description?: T;
+  type?: T;
+  readTime?: T;
+  heroImage?: T;
+  heroImageCaption?: T;
+  content?: T;
+  author?:
+    | T
+    | {
+        picture?: T;
+        name?: T;
+        role?: T;
+        bio?: T;
+        social?:
+          | T
+          | {
+              linkedin?: T;
+              twitter?: T;
+              email?: T;
+            };
+      };
+  publishDate?: T;
+  status?: T;
+  seo?:
+    | T
+    | {
+        metaTitle?: T;
+        metaDescription?: T;
+        ogImage?: T;
+      };
+  publishedAt?: T;
+  updatedAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/apps/backoffice/src/app/public-api/articles/[slug]/route.ts
+++ b/apps/backoffice/src/app/public-api/articles/[slug]/route.ts
@@ -1,0 +1,66 @@
+/* * */
+
+import payloadConfig from '@/payload-config';
+import { getPublicHeaders } from '@/utils/get-public-headers';
+import { getPayload } from 'payload';
+
+/* * */
+
+export const GET = async (_request: Request, { params }: { params: Promise<{ slug: string }> }) => {
+	//
+
+	//
+	// Setup Payload and other necessary variables for handling requests.
+
+	const { slug } = await params;
+	const payload = await getPayload({ config: payloadConfig });
+
+	//
+	// Retrieve the article by slug from the database.
+
+	const foundItems = await payload.find({
+		collection: 'articles',
+		depth: 2,
+		limit: 1,
+		where: {
+			slug: { equals: slug },
+			status: { equals: 'published' },
+		},
+	});
+
+	//
+	// Check if article was found
+
+	if (!foundItems.docs.length) {
+		return Response.json({ error: 'Article not found' }, { status: 404 });
+	}
+
+	const item = foundItems.docs[0];
+
+	//
+	// Format the article data for public consumption
+
+	const publicItem = {
+		_id: item.id,
+		author: item.author,
+		content: item.content,
+		description: item.description,
+		heroImage: item.heroImage,
+		heroImageCaption: item.heroImageCaption,
+		publishDate: item.publishDate,
+		readTime: item.readTime,
+		seo: item.seo,
+		slug: item.slug,
+		title: item.title,
+		type: item.type,
+	};
+
+	//
+	// Return the article as a JSON response.
+
+	return Response.json(publicItem, {
+		headers: getPublicHeaders(60),
+	});
+
+	//
+};

--- a/apps/backoffice/src/app/public-api/articles/route.ts
+++ b/apps/backoffice/src/app/public-api/articles/route.ts
@@ -1,0 +1,57 @@
+/* * */
+
+import payloadConfig from '@/payload-config';
+import { getPublicHeaders } from '@/utils/get-public-headers';
+import { getPayload } from 'payload';
+
+/* * */
+
+export const GET = async () => {
+	//
+
+	//
+	// Setup Payload and other necessary variables for handling requests.
+
+	const payload = await getPayload({ config: payloadConfig });
+
+	//
+	// Retrieve all published articles from the database.
+
+	const foundItems = await payload.find({
+		collection: 'articles',
+		depth: 2,
+		limit: 0,
+		sort: '-publishDate',
+		where: {
+			status: { equals: 'published' },
+		},
+	});
+
+	//
+	// Format the articles data for public consumption
+
+	const publicItems = foundItems.docs.map((item) => {
+		return {
+			_id: item.id,
+			author: item.author,
+			description: item.description,
+			heroImage: item.heroImage,
+			heroImageCaption: item.heroImageCaption,
+			publishDate: item.publishDate,
+			readTime: item.readTime,
+			seo: item.seo,
+			slug: item.slug,
+			title: item.title,
+			type: item.type,
+		};
+	});
+
+	//
+	// Return the articles as a JSON response.
+
+	return Response.json(publicItems, {
+		headers: getPublicHeaders(60),
+	});
+
+	//
+};

--- a/apps/backoffice/src/payload-config.ts
+++ b/apps/backoffice/src/payload-config.ts
@@ -10,6 +10,7 @@ import sharp from 'sharp';
 
 /* * */
 
+import { Articles } from '@/schemas/Articles/collection';
 import { CaseStudies } from '@/schemas/CaseStudies/collection';
 import { KnowledgeBase } from '@/schemas/KnowledgeBase/collection';
 import { Media } from '@/schemas/Media/collection';
@@ -30,6 +31,7 @@ export default buildConfig({
 	admin: { user: 'users' },
 
 	collections: [
+		Articles,
 		CaseStudies,
 		KnowledgeBase,
 		Media,

--- a/apps/backoffice/src/schemas/Articles/collection.ts
+++ b/apps/backoffice/src/schemas/Articles/collection.ts
@@ -1,0 +1,270 @@
+/* * */
+
+import { publishedAtField } from '@/fields/published-at';
+import { updatedAtField } from '@/fields/updated-at';
+import { slugify } from '@/utils/slugify';
+import { type CollectionConfig } from 'payload';
+
+/* * */
+
+export const Articles: CollectionConfig = {
+
+	access: {
+		create: ({ req: { user } }) => Boolean(user),
+		delete: ({ req: { user } }) => Boolean(user),
+		read: ({ req: { user } }) => {
+			// If user is authenticated, return all records
+			if (user) return true;
+			// Otherwise, only return published records
+			return { status: { equals: 'published' } };
+		},
+		update: ({ req: { user } }) => Boolean(user),
+	},
+
+	admin: {
+		defaultColumns: ['title', 'status', 'type', 'publishDate'],
+		useAsTitle: 'title',
+	},
+
+	fields: [
+		{
+			label: 'Título',
+			maxLength: 200,
+			name: 'title',
+			required: true,
+			type: 'text',
+		},
+		{
+			admin: {
+				description: 'URL única para este artigo. Será gerada automaticamente do título se deixado em branco.',
+			},
+			index: true,
+			label: 'Slug',
+			name: 'slug',
+			required: true,
+			type: 'text',
+			unique: true,
+		},
+		{
+			admin: {
+				description: 'Resumo curto do artigo que aparece na listagem e no início do artigo.',
+			},
+			label: 'Descrição',
+			maxLength: 500,
+			name: 'description',
+			required: true,
+			type: 'textarea',
+		},
+		{
+			admin: {
+				position: 'sidebar',
+			},
+			label: 'Tipo',
+			name: 'type',
+			options: [
+				{
+					label: 'Tecnologia',
+					value: 'tecnologia',
+				},
+				{
+					label: 'Operação',
+					value: 'operacao',
+				},
+				{
+					label: 'Sustentabilidade',
+					value: 'sustentabilidade',
+				},
+				{
+					label: 'Comunicação',
+					value: 'comunicacao',
+				},
+			],
+			required: true,
+			type: 'select',
+		},
+		{
+			admin: {
+				description: 'Tempo estimado de leitura em minutos.',
+				position: 'sidebar',
+			},
+			defaultValue: 5,
+			label: 'Tempo de Leitura (min)',
+			min: 1,
+			name: 'readTime',
+			required: true,
+			type: 'number',
+		},
+		{
+			admin: {
+				position: 'sidebar',
+			},
+			label: 'Imagem de Destaque',
+			name: 'heroImage',
+			relationTo: 'media',
+			required: true,
+			type: 'upload',
+		},
+		{
+			admin: {
+				description: 'Legenda que aparece sobre a imagem de destaque.',
+			},
+			label: 'Legenda da Imagem',
+			maxLength: 200,
+			name: 'heroImageCaption',
+			type: 'text',
+		},
+		{
+			admin: {
+				description: 'Conteúdo do artigo em formato Markdown. Suporta títulos (##), listas, links, citações e muito mais.',
+			},
+			label: 'Conteúdo (Markdown)',
+			name: 'content',
+			required: true,
+			type: 'textarea',
+		},
+		{
+			fields: [
+				{
+					label: 'Foto',
+					name: 'picture',
+					relationTo: 'media',
+					type: 'upload',
+				},
+				{
+					label: 'Nome',
+					name: 'name',
+					required: true,
+					type: 'text',
+				},
+				{
+					label: 'Cargo/Função',
+					name: 'role',
+					required: true,
+					type: 'text',
+				},
+				{
+					admin: {
+						description: 'Breve descrição sobre o autor.',
+					},
+					label: 'Biografia',
+					name: 'bio',
+					type: 'textarea',
+				},
+				{
+					fields: [
+						{
+							label: 'LinkedIn',
+							name: 'linkedin',
+							type: 'text',
+						},
+						{
+							label: 'X (Twitter)',
+							name: 'twitter',
+							type: 'text',
+						},
+						{
+							label: 'Email',
+							name: 'email',
+							type: 'email',
+						},
+					],
+					label: 'Redes Sociais',
+					name: 'social',
+					type: 'group',
+				},
+			],
+			label: 'Autor',
+			name: 'author',
+			type: 'group',
+		},
+		{
+			admin: {
+				date: {
+					pickerAppearance: 'dayAndTime',
+				},
+				position: 'sidebar',
+			},
+			defaultValue: () => new Date(),
+			label: 'Data de Publicação',
+			name: 'publishDate',
+			required: true,
+			type: 'date',
+		},
+		{
+			admin: {
+				position: 'sidebar',
+			},
+			defaultValue: 'draft',
+			label: 'Status',
+			name: 'status',
+			options: [
+				{
+					label: 'Rascunho',
+					value: 'draft',
+				},
+				{
+					label: 'Publicado',
+					value: 'published',
+				},
+			],
+			required: true,
+			type: 'select',
+		},
+		{
+			fields: [
+				{
+					label: 'Título Meta',
+					maxLength: 60,
+					name: 'metaTitle',
+					type: 'text',
+				},
+				{
+					label: 'Descrição Meta',
+					maxLength: 160,
+					name: 'metaDescription',
+					type: 'textarea',
+				},
+				{
+					label: 'Imagem OG',
+					name: 'ogImage',
+					relationTo: 'media',
+					type: 'upload',
+				},
+			],
+			label: 'SEO',
+			name: 'seo',
+			type: 'group',
+		},
+		publishedAtField,
+		updatedAtField,
+	],
+
+	hooks: {
+		beforeChange: [
+			async ({ data }) => {
+				// Set publishDate if publishing without date
+				if (data.status === 'published' && !data.publishDate) {
+					data.publishDate = new Date();
+				}
+			},
+		],
+		beforeValidate: [
+			async ({ data }) => {
+				// Auto-generate slug if empty
+				if (data.title && !data.slug) {
+					data.slug = slugify(data.title);
+				}
+			},
+		],
+	},
+
+	labels: {
+		plural: 'Artigos',
+		singular: 'Artigo',
+	},
+
+	slug: 'articles',
+
+	timestamps: false,
+
+};


### PR DESCRIPTION
## Summary

Add new **Articles** collection to the backoffice CMS for managing blog/news articles with markdown content support.

## New Collection: Articles

### Fields

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `title` | text (max 200) | Yes | Article title |
| `slug` | text (unique, indexed) | Yes | URL-friendly identifier, auto-generated from title |
| `description` | textarea (max 500) | Yes | Short summary for listings |
| `type` | select | Yes | `tecnologia`, `operacao`, `sustentabilidade`, `comunicacao` |
| `readTime` | number (min 1, default 5) | Yes | Estimated reading time in minutes |
| `heroImage` | upload (media) | Yes | Featured image |
| `heroImageCaption` | text (max 200) | No | Caption displayed over hero image |
| `content` | textarea | Yes | Article body in **Markdown** format |
| `author` | group | No | Author details (see below) |
| `publishDate` | date | Yes | Publication date |
| `status` | select | Yes | `draft` / `published` |
| `seo` | group | No | SEO metadata (metaTitle, metaDescription, ogImage) |

### Author Group Fields

| Field | Type | Description |
|-------|------|-------------|
| `picture` | upload (media) | Author photo |
| `name` | text | Author name |
| `role` | text | Author role/position |
| `bio` | textarea | Short biography |
| `social.linkedin` | text | LinkedIn URL |
| `social.twitter` | text | X (Twitter) URL |
| `social.email` | email | Contact email |

## Public API Endpoints

### List Articles

``GET /public-api/articles``

Returns all published articles sorted by `publishDate` (newest first).

**Response fields:** `_id`, `title`, `slug`, `description`, `type`, `readTime`, `heroImage`, `heroImageCaption`, `author`, `publishDate`, `seo`

### Get Single Article

``GET /public-api/articles/[slug]``

Returns full article data including markdown `content`.

**Response fields:** All list fields + `content`

## Files Changed

- `apps/backoffice/src/schemas/Articles/collection.ts` - New collection schema
- `apps/backoffice/src/payload-config.ts` - Register Articles collection
- `apps/backoffice/src/app/public-api/articles/route.ts` - List endpoint
- `apps/backoffice/src/app/public-api/articles/[slug]/route.ts` - Detail endpoint

## Notes

- Content field uses **Markdown** format for flexibility in frontend rendering
- Follows existing patterns from `knowledge-base` collection
- Access control: authenticated users have full access, public users can only read published articles
- Slug is auto-generated from title if left empty
- Cache: 60 seconds on both endpoints
