### PR TITLE
[Feature/Improvement] Add Public Holidays to Operational Date calendar

### DIFF
--- a/apps/frontend/src/components/common/SelectOperationalDate/index.tsx
+++ b/apps/frontend/src/components/common/SelectOperationalDate/index.tsx
@@ -2,25 +2,106 @@
 
 /* * */
 
+import { useLocaleContext } from '@/contexts/Locale.context';
 import { useOperationalDateContext } from '@/contexts/OperationalDate.context';
-import { SegmentedControl } from '@mantine/core';
-import { DatePickerInput } from '@mantine/dates';
+import { SegmentedControl, Tooltip } from '@mantine/core';
+import { DatePickerInput, DatePickerProps } from '@mantine/dates';
 import { IconCalendarEvent } from '@tabler/icons-react';
+import dayjs from 'dayjs';
 import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 
 import styles from './styles.module.css';
 
-/* * */
+function getOffsetDate(date, offsetDays) {
+	const newDate = new Date(date);
+	newDate.setDate(newDate.getDate() + offsetDays);
+	return { day: newDate.getDate(), month: (newDate.getMonth() + 1) };
+}
 
+function getMobileHolidays(year) {
+	// probably going down a rabbit hole with this one
+
+	// Finds Easter's day/month from a given year
+	const f = Math.floor;
+	const G = year % 19;
+	const C = f(year / 100);
+	const H = (C - f(C / 4) - f((8 * C + 13) / 25) + 19 * G + 15) % 30;
+	const I = H - f(H / 28) * (1 - f(29 / (H + 1)) * f((21 - G) / 11));
+	const J = (year + f(year / 4) + I + 2 - C + f(C / 4)) % 7;
+	const L = I - J;
+	const month = 3 + f((L + 40) / 44);
+	const day = L + 28 - 31 * f(month / 4);
+
+	const date = new Date(year, month - 1, day);
+
+	return { carnival: getOffsetDate(date, -47), corpusChristi: getOffsetDate(date, 60), easter: { day: day, month: month }, goodFriday: getOffsetDate(date, -2) };
+}
+
+function checkHoliday(calendarDate: dayjs.Dayjs): [boolean, string, string] {
+	const day = calendarDate.date();
+	const month = calendarDate.month() + 1;
+	const year = calendarDate.year();
+
+	if (day === 25 && month === 12) return [true, 'christmasHoliday', 'publicHolidayNames.christmas']; // 25/12 | Christmas / Natal
+	if (day === 8 && month === 12) return [true, 'publicHoliday', 'publicHolidayNames.imaculadaConceicao']; // 08/12 | Dia da Imaculada Conceição
+	if (day === 1 && month === 12) return [true, 'publicHoliday', 'publicHolidayNames.restauracaoIndependencia']; // 01/12 | Dia da Restauração da Independência
+	if (day === 1 && month === 11) return [true, 'publicHoliday', 'publicHolidayNames.todosOsSantos']; // 01/11 | Dia de Todos os Santos
+	if (day === 5 && month === 10) return [true, 'publicHoliday', 'publicHolidayNames.implatacaoRepublica']; // 05/10 | Dia da Implatação da República
+	if (day === 15 && month === 8) return [true, 'publicHoliday', 'publicHolidayNames.assuncaoNossaSenhora']; // 15/08 | Dia da Assunção de Nossa Senhora
+	if (day === 10 && month === 6) return [true, 'publicHoliday', 'publicHolidayNames.diaDePortugal']; // 10/06 | Dia de Portugal, Camões e das comunidades Portuguesas
+	if (day === 1 && month === 5) return [true, 'publicHoliday', 'publicHolidayNames.diaDoTrabalhador']; // 01/05 | Dia do Trabalhador
+	if (day === 25 && month === 4) return [true, 'publicHoliday', 'publicHolidayNames.diaDaLiberdade']; // 25/04 | Dia da Liberdade (25 de ABril)
+	if (day === 1 && month === 1) return [true, 'publicHoliday', 'publicHolidayNames.newYears']; // 01/01 | New Years Day / Ano Novo
+
+	// mobile holidays here we go - Easter, Sexta-Feira Santa, Carnaval and Corpo de Deus
+	const mobileHolidays = getMobileHolidays(year);
+
+	if (day === mobileHolidays.easter.day && month === mobileHolidays.easter.month) return [true, 'easterHoliday', 'publicHolidayNames.easter'];
+	if (day === mobileHolidays.carnival.day && month === mobileHolidays.carnival.month) return [true, 'publicHoliday', 'publicHolidayNames.carnival'];
+	if (day === mobileHolidays.corpusChristi.day && month === mobileHolidays.corpusChristi.month) return [true, 'publicHoliday', 'publicHolidayNames.corpusChristi'];
+	if (day === mobileHolidays.goodFriday.day && month === mobileHolidays.goodFriday.month) return [true, 'publicHoliday', 'publicHolidayNames.goodFriday'];
+
+	return [false, '', ''];
+}
+
+/* * */
 export function SelectOperationalDate() {
 	//
 
 	//
 	// A. Setup variables
 
+	// The current dates endpoint is missing some holidays (i.e. Easter 2026). As such, it can't be used until these issues are fixed. Addtionally, this endpoint "only" returns dates up to 2029
+	// const { data: operationalDates } = useSWR<ApiOperationalDate[]>(`${getPublicVariable('api_url')}/dates`, { refreshInterval: 900000 });
+
 	const t = useTranslations('common.SelectOperationalDate');
 	const operationalDateContext = useOperationalDateContext();
+
+	const dayRenderer: DatePickerProps['renderDay'] = (date) => {
+		const calendarDate = dayjs(date);
+		const day = calendarDate.date();
+		const year = calendarDate.year();
+		const isHoliday = checkHoliday(calendarDate);
+		if (isHoliday[0]) {
+			return (
+				<Tooltip
+					events={{ focus: true, hover: true, touch: true }}
+					label={t(isHoliday[2], { year: year })}
+					withArrow
+				>
+					<div className={isHoliday[0] ? styles.publicHoliday : ''}>
+						{t(isHoliday[1])}
+					</div>
+				</Tooltip>
+			);
+		}
+		else {
+			return (
+				day
+			);
+		}
+	};
 
 	const [selectedSegmentedControlOption, setSelectedSegmentedControlOption] = useState<string | undefined>();
 
@@ -40,7 +121,9 @@ export function SelectOperationalDate() {
 					data-selected={!operationalDateContext.flags.is_today_selected && !operationalDateContext.flags.is_tomorrow_selected}
 					dropdownType="modal"
 					leftSection={<IconCalendarEvent />}
+					locale={useLocaleContext().data.current_locale || 'pt'}
 					onChange={operationalDateContext.actions.updateSelectedDateFromFormat}
+					renderDay={dayRenderer}
 					size="lg"
 					value={operationalDateContext.data.selected_date?.js_date}
 					valueFormat="DD MMM YYYY"

--- a/apps/frontend/src/components/common/SelectOperationalDate/index.tsx
+++ b/apps/frontend/src/components/common/SelectOperationalDate/index.tsx
@@ -65,6 +65,33 @@ function checkHoliday(calendarDate: dayjs.Dayjs): [boolean, string, string] {
 	return [false, '', ''];
 }
 
+export const dayRenderer: DatePickerProps['renderDay'] = (date) => {
+	const t = useTranslations('common.SelectOperationalDate');
+
+	const calendarDate = dayjs(date);
+	const day = calendarDate.date();
+	const year = calendarDate.year();
+	const isHoliday = checkHoliday(calendarDate);
+	if (isHoliday[0]) {
+		return (
+			<Tooltip
+				events={{ focus: true, hover: true, touch: true }}
+				label={t(isHoliday[2], { year: year })}
+				withArrow
+			>
+				<div className={isHoliday[0] ? styles.publicHoliday : ''}>
+					{t(isHoliday[1])}
+				</div>
+			</Tooltip>
+		);
+	}
+	else {
+		return (
+			day
+		);
+	}
+};
+
 /* * */
 export function SelectOperationalDate() {
 	//
@@ -77,31 +104,6 @@ export function SelectOperationalDate() {
 
 	const t = useTranslations('common.SelectOperationalDate');
 	const operationalDateContext = useOperationalDateContext();
-
-	const dayRenderer: DatePickerProps['renderDay'] = (date) => {
-		const calendarDate = dayjs(date);
-		const day = calendarDate.date();
-		const year = calendarDate.year();
-		const isHoliday = checkHoliday(calendarDate);
-		if (isHoliday[0]) {
-			return (
-				<Tooltip
-					events={{ focus: true, hover: true, touch: true }}
-					label={t(isHoliday[2], { year: year })}
-					withArrow
-				>
-					<div className={isHoliday[0] ? styles.publicHoliday : ''}>
-						{t(isHoliday[1])}
-					</div>
-				</Tooltip>
-			);
-		}
-		else {
-			return (
-				day
-			);
-		}
-	};
 
 	const [selectedSegmentedControlOption, setSelectedSegmentedControlOption] = useState<string | undefined>();
 

--- a/apps/frontend/src/components/common/SelectOperationalDate/styles.module.css
+++ b/apps/frontend/src/components/common/SelectOperationalDate/styles.module.css
@@ -92,3 +92,9 @@
 		width: 20px;
 	}
 }
+
+/* * */
+/* DATE PICKER / PUBLIC HOLIDAY DATE OVERRIDE */
+.publicHoliday {
+	color: var(--mantine-color-red-6) !important;
+}

--- a/apps/frontend/src/components/metrics/MetricsPagePassengers/index.tsx
+++ b/apps/frontend/src/components/metrics/MetricsPagePassengers/index.tsx
@@ -2,6 +2,7 @@
 
 /* * */
 
+import { dayRenderer } from '@/components/common/SelectOperationalDate';
 import { Section } from '@/components/layout/Section';
 import { Surface } from '@/components/layout/Surface';
 import { LastUpdatedAt } from '@/components/metrics/LastUpdatedAt';
@@ -10,7 +11,8 @@ import { MetricsPagePassengersMonth } from '@/components/metrics/MetricsPagePass
 import { useLocaleContext } from '@/contexts/Locale.context';
 import { useMetricsContext } from '@/contexts/Metrics.context';
 import { SegmentedControl } from '@mantine/core';
-import { DatePickerInput } from '@mantine/dates';
+import { DatePickerInput, DatePickerProps } from '@mantine/dates';
+import dayjs from 'dayjs';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 
@@ -58,6 +60,7 @@ export function MetricsPagePassengers() {
 							minDate={new Date('2024-01-01')}
 							onChange={actions.setStartDate}
 							placeholder={t('dates.start_date')}
+							renderDay={dayRenderer}
 							value={filters.startDate.js_date}
 						/>
 						<DatePickerInput
@@ -67,6 +70,7 @@ export function MetricsPagePassengers() {
 							minDate={filters.startDate.js_date}
 							onChange={actions.setEndDate}
 							placeholder={t('dates.end_date')}
+							renderDay={dayRenderer}
 							value={filters.endDate.js_date}
 						/>
 					</div>

--- a/apps/frontend/src/i18n/translations/en.json
+++ b/apps/frontend/src/i18n/translations/en.json
@@ -506,7 +506,7 @@
 			}
 		},
 		"FavoriteToggle": {
-			"disabled": "É necessário permitir cookies para adicionar favoritos"
+			"disabled": "You must allow cookies to add favorites"
 		},
 		"NextArrivals": {
 			"arriving": "Coming up",
@@ -517,6 +517,25 @@
 			"label": "Back to Top"
 		},
 		"SelectOperationalDate": {
+			"christmasHoliday": "C",
+			"easterHoliday": "E",
+			"publicHoliday": "H",
+			"publicHolidayNames": {
+				"assuncaoNossaSenhora": "Assumption of Mary",
+				"carnival": "Carnival {year}",
+				"christmas": "Christmas {year}",
+				"corpusChristi": "Corpus Christi {year}",
+				"diaDaLiberdade": "Liberty Day (25th April)",
+				"diaDePortugal": "Portugal, Camões and Portuguese Communities Day",
+				"diaDoTrabalhador": "Labour Day",
+				"easter": "Easter {year}",
+				"goodFriday": "Good Friday {year}",
+				"imaculadaConceicao": "Feast of the Immaculate Conception",
+				"implatacaoRepublica": "Republic Implementation Day",
+				"newYears": "New Years Day {year}",
+				"restauracaoIndependencia": "Restoration of Independence Day",
+				"todosOsSantos": "All Saints' Day"
+			},
 			"today": "Today",
 			"tomorrow": "Tomorrow"
 		},
@@ -1488,9 +1507,9 @@
 		"VehiclePropulsion": {
 			"diesel": "Diesel",
 			"electricity": "Electricity",
+			"hybrid": "Hybrid",
 			"lpg_auto": "GPL",
-			"natural_gas": "Natural Gas",
-			"hybrid": "Hybrid"
+			"natural_gas": "Natural Gas"
 		}
 	},
 	"periods": {

--- a/apps/frontend/src/i18n/translations/pt.json
+++ b/apps/frontend/src/i18n/translations/pt.json
@@ -517,6 +517,25 @@
 			"label": "Início da Página"
 		},
 		"SelectOperationalDate": {
+			"christmasHoliday": "N",
+			"easterHoliday": "P",
+			"publicHoliday": "F",
+			"publicHolidayNames": {
+				"assuncaoNossaSenhora": "Dia da Assunção de Nossa Senhora",
+				"carnival": "Carnaval {year}",
+				"christmas": "Natal {year}",
+				"corpusChristi": "Corpo de Deus {year}",
+				"diaDaLiberdade": "Dia da Liberdade (25 de abril)",
+				"diaDePortugal": "Dia de Portugal, de Camões e das Comunidades Portuguesas",
+				"diaDoTrabalhador": "Dia do Trabalhador",
+				"easter": "Páscoa {year}",
+				"goodFriday": "Sexta-Feira Santa {year}",
+				"imaculadaConceicao": "Dia da Imaculada Conceição",
+				"implatacaoRepublica": "Dia da Implatação da República",
+				"newYears": "Ano Novo {year}",
+				"restauracaoIndependencia": "Dia da Restauração da Independência",
+				"todosOsSantos": "Dia de Todos os Santos"
+			},
 			"today": "Hoje",
 			"tomorrow": "Amanhã"
 		},
@@ -1489,9 +1508,9 @@
 		"VehiclePropulsion": {
 			"diesel": "Diesel",
 			"electricity": "Eletricidade",
+			"hybrid": "Híbrido",
 			"lpg_auto": "GPL",
-			"natural_gas": "Gás Natural",
-			"hybrid": "Híbrido"
+			"natural_gas": "Gás Natural"
 		}
 	},
 	"periods": {


### PR DESCRIPTION
This PR solves [Issue #219](https://github.com/carrismetropolitana/website/issues/219) by highlighting public holidays on the Operational Date calendar, marking them in red (just like weekend days) and replacing the displayed number with "F" (or "N"/"P" for Christmas/Easter) or "H" (or "C"/"E" for Christmas/Easter) depending on the user's locale.
Each holiday day also features a tooltip that is automaticly translated to the user's locale.
<img width="508" height="506" alt="IOkgdDK" src="https://github.com/user-attachments/assets/696a9de6-fb6f-46d4-9c54-6b8574bac6bf" />
<img width="501" height="507" alt="ErSvdBv" src="https://github.com/user-attachments/assets/f3de67b4-0ba7-4855-9ccb-92ba2b0b2437" />

Additionally, fixed the following issues:
- common.FavoriteToggle.disabled was incorrecticly translated to portuguese on en.json
- The calendar didn't change to the user's locale, instead defaulting to the computer's locale. Now, the calendar's locale is defined by `useLocaleContext().data.current_locale` or `pt` as a fallback option
