### PR TITLE
Feature - Add fleet page

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -127,7 +127,7 @@ const nextConfig: NextConfig = {
 			{ destination: '/about', permanent: true, source: '/sobre' },
 
 			{ destination: '/vehicles', permanent: true, source: '/veiculos' },
-			{ destination: '/vehicles', permanent: true, source: '/frota' },
+			{ destination: '/fleet', permanent: true, source: '/frota' },
 
 			/* * */
 			/* UNLISTED */

--- a/apps/frontend/src/app/(views)/(website)/fleet/layout.tsx
+++ b/apps/frontend/src/app/(views)/(website)/fleet/layout.tsx
@@ -1,0 +1,24 @@
+/* * */
+
+import { FleetContextProvider } from '@/contexts/Fleet.context';
+import { FleetListContextProvider } from '@/contexts/FleetList.context';
+import { type Metadata } from 'next';
+
+/* * */
+
+export const metadata: Metadata = {
+	description: 'Explore a frota completa da CMetropolitana.',
+	title: 'CMetropolitana | Frota',
+};
+
+/* * */
+
+export default function Layout({ children }) {
+	return (
+		<FleetContextProvider>
+			<FleetListContextProvider>
+				{children}
+			</FleetListContextProvider>
+		</FleetContextProvider>
+	);
+}

--- a/apps/frontend/src/app/(views)/(website)/fleet/page.tsx
+++ b/apps/frontend/src/app/(views)/(website)/fleet/page.tsx
@@ -1,0 +1,8 @@
+/* * */
+
+import { FleetPage } from '@/components/fleet/FleetPage';
+/* * */
+
+export default function Page() {
+	return <FleetPage />;
+}

--- a/apps/frontend/src/app/(views)/(website)/vehicles/layout.tsx
+++ b/apps/frontend/src/app/(views)/(website)/vehicles/layout.tsx
@@ -7,7 +7,7 @@ import { type Metadata } from 'next';
 
 export const metadata: Metadata = {
 	description: 'Explore todos os veículos da CMetropolitana em tempo real.',
-	title: 'CMetropolitana | Frota',
+	title: 'CMetropolitana | Veículos a circular',
 };
 
 /* * */

--- a/apps/frontend/src/components/fleet/FleetDisplay/index.tsx
+++ b/apps/frontend/src/components/fleet/FleetDisplay/index.tsx
@@ -1,0 +1,120 @@
+/* * */
+
+import type { Vehicle } from '@carrismetropolitana/api-types/vehicles';
+
+import { LiveIcon } from '@/components/common/LiveIcon';
+import { LineBadge } from '@/components/lines/LineBadge';
+import { useFleetContext } from '@/contexts/Fleet.context';
+import { Skeleton } from '@mantine/core';
+import { IconCircleCheck, IconCircleX, IconCreditCard, IconWifiOff } from '@tabler/icons-react';
+import { useTranslations } from 'next-intl';
+
+import styles from './styles.module.css';
+
+/* * */
+
+interface Props {
+	isHeader?: boolean
+	vehicleData?: Vehicle
+	width?: number
+}
+
+/* * */
+
+function getOperatorFromAgencyId(agency_id) {
+	switch (agency_id) {
+		case '41':
+			return 'V. Alvorada';
+		case '42':
+			return 'RL';
+		case '43':
+			return 'TST';
+		case '44':
+			return 'Alsa Todi';
+		default:
+			return 'ERRO';
+	}
+}
+
+export function FleetDisplay({ isHeader, vehicleData, width = 200 }: Props) {
+	//
+
+	const t = useTranslations('fleet');
+	const propulsionT = useTranslations('options.VehiclePropulsion');
+
+	const fleetContext = useFleetContext();
+
+	function getVehicleStatus(vehicleData: Vehicle) {
+		const tripId = vehicleData.trip_id;
+		if (!tripId) return (<div className={styles.statusDiv}><IconWifiOff color="red" /><span>{t('FleetList.status.no_data')}</span></div>);
+		const lastPing = vehicleData.timestamp;
+		const now = Date.now() / 1000;
+
+		// If last ping is from over 7 days ago
+		if (lastPing < (now - 604_800)) {
+			return (<span>{t('FleetList.status.inactive')}</span>);
+		}
+
+		const currentOperationalDate = fleetContext.actions.getOperationalDate().getTime() / 1000;
+
+		if (lastPing < (currentOperationalDate)) {
+			return (<div className={[styles.statusDiv, styles.pastDeparture].join(' ')}><span>{t('FleetList.status.activeWeek', { days: Math.floor((currentOperationalDate - lastPing) / 86_400) + 1 })}</span></div>);
+		}
+
+		if (lastPing > currentOperationalDate && lastPing < (now - 3600)) return (<div className={[styles.statusDiv, styles.pastDeparture].join(' ')}><span>{t('FleetList.status.activeToday', { hours: Math.floor((now - lastPing) / 3600) })}</span><LineBadge lineId={vehicleData.line_id || 'CP'} shortName={(vehicleData.line_id === '1998' || vehicleData.line_id === '1999') ? 'CP' : vehicleData.line_id} /></div>);
+
+		if (lastPing > currentOperationalDate && lastPing < (now - 120)) return (<div className={[styles.statusDiv, styles.pastDeparture].join(' ')}><span>{t('FleetList.status.activeHour', { mins: Math.floor((now - lastPing) / 60) })}</span><LineBadge lineId={vehicleData.line_id || 'CP'} shortName={(vehicleData.line_id === '1998' || vehicleData.line_id === '1999') ? 'CP' : vehicleData.line_id} /></div>);
+
+		return (<div className={styles.statusDiv}><LiveIcon /><span>{t('FleetList.status.activeNow')}</span><LineBadge lineId={vehicleData.line_id || 'CP'} shortName={(vehicleData.line_id === '1998' || vehicleData.line_id === '1999') ? 'CP' : vehicleData.line_id} /></div>);
+	}
+
+	if (isHeader) {
+		return (
+			<>
+				<tr className={styles.tableHeader}>
+					<th rowSpan={2}># Frota</th>
+					<th rowSpan={2}>Operador</th>
+					<th rowSpan={2}><IconCreditCard /></th>
+					<th rowSpan={2}>Propulsão</th>
+					<th rowSpan={2}>Modelo</th>
+					<th colSpan={3}>Capacidade</th>
+					<th className={styles.tableHeaderLastChild} rowSpan={2}>Estado</th>
+				</tr>
+				<tr className={styles.tableHeader}>
+					<th>S</th>
+					<th>P</th>
+					<th>Total</th>
+				</tr>
+			</>
+		);
+	}
+
+	if (vehicleData) {
+		return (
+			<tr className={styles.tableCell}>
+				<td>{vehicleData.id}</td>
+				<td>{getOperatorFromAgencyId(vehicleData.agency_id)}</td>
+				<td>{vehicleData.contactless ? <IconCircleCheck color="green" /> : <IconCircleX color="red" />}</td>
+				<td>{vehicleData.propulsion ? propulsionT(`${vehicleData.propulsion}`) : 'N/A'}</td>
+				<td>{(vehicleData.make ? (vehicleData.make + ' - ' + vehicleData.model) : 'Desconhecido')}</td>
+				<td>{vehicleData.capacity_seated}</td>
+				<td>{vehicleData.capacity_standing}</td>
+				<td>{vehicleData.capacity_total}</td>
+				<td>{getVehicleStatus(vehicleData)}</td>
+			</tr>
+		);
+	}
+
+	return (
+		<tr className={styles.tableCell}>
+			<td><Skeleton height={24} width={50} /></td>
+			<td><Skeleton height={24} width={150} /></td>
+			<td><Skeleton height={24} width={50} /></td>
+			<td><Skeleton height={24} width={150} /></td>
+			<td><Skeleton height={24} width={width} /></td>
+			<td><Skeleton height={24} width={100} /></td>
+		</tr>
+	);
+
+	//
+}

--- a/apps/frontend/src/components/fleet/FleetDisplay/styles.module.css
+++ b/apps/frontend/src/components/fleet/FleetDisplay/styles.module.css
@@ -1,0 +1,56 @@
+/* * */
+/* CONTAINER */
+
+.tableHeader {
+	width: 100%;
+	background-color: var(--color-system-background-200);
+}
+
+.tableHeader th {
+	align-items: center;
+	justify-content: flex-start;
+	padding: var(--size-spacing-10);
+	white-space: nowrap;
+	
+}
+
+.tableHeaderLastChild {
+	width: 100%;
+}
+
+.tableCell {
+	width: 100%;
+}
+
+.tableCell td {
+	padding: var(--size-spacing-10);;
+	text-align: center;
+	white-space: nowrap;
+}
+
+.tableCell td:last-child {
+	width: 100%;
+}
+
+.container {
+	display: flex;
+	flex-direction: row;
+	gap: var(--size-spacing-10);
+	align-items: center;
+	justify-content: flex-start;
+}
+
+.statusDiv {
+	display: flex;
+	flex-direction: row;
+	gap: var(--size-spacing-5);
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	text-align: center;
+}
+
+.pastDeparture span {
+	font-style: italic;
+	color: var(--color-system-text-200);
+}

--- a/apps/frontend/src/components/fleet/FleetList/index.tsx
+++ b/apps/frontend/src/components/fleet/FleetList/index.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+/* * */
+
+import { FleetListToolbar } from '@/components/fleet/FleetListToolbar';
+import { FleetListView } from '@/components/fleet/FleetListView';
+
+/* * */
+
+export function FleetList() {
+	return (
+		<>
+			<FleetListToolbar />
+			<FleetListView />
+		</>
+	);
+
+	//
+}

--- a/apps/frontend/src/components/fleet/FleetListTable/index.tsx
+++ b/apps/frontend/src/components/fleet/FleetListTable/index.tsx
@@ -1,0 +1,27 @@
+import { FleetRow } from '@/components/fleet/FleetRow';
+import { useFleetListContext } from '@/contexts/FleetList.context';
+import { ViewportList } from 'react-viewport-list';
+
+import styles from './styles.module.css';
+
+export function FleetListTable() {
+	const fleetListContext = useFleetListContext();
+
+	return (
+		<div className={styles.table}>
+			<div className={styles.header}>
+				<FleetRow isHeader={true} />
+			</div>
+			<div className={styles.body}>
+				{fleetListContext.flags.is_loading && [200, 120, 180, 200, 100, 120, 250, 120, 130, 220, 90].map((width, index) => (
+					<FleetRow key={index} width={width} />
+				))}
+				{!fleetListContext.flags.is_loading && (
+					<ViewportList items={fleetListContext.data.filtered}>
+						{vehicle => <FleetRow key={vehicle.id} vehicleData={vehicle} />}
+					</ViewportList>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/frontend/src/components/fleet/FleetListTable/styles.module.css
+++ b/apps/frontend/src/components/fleet/FleetListTable/styles.module.css
@@ -1,0 +1,18 @@
+.table {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  font-weight: 600;
+  background: var(--color-system-background-200);
+}
+
+.body {
+    max-height: 100vh;
+    overflow-y: auto;
+}

--- a/apps/frontend/src/components/fleet/FleetListToolbar/index.tsx
+++ b/apps/frontend/src/components/fleet/FleetListToolbar/index.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+/* * */
+
+import { ExpandToggle } from '@/components/common/ExpandToggle';
+import { FoundItemsCounter } from '@/components/common/FoundItemsCounter';
+import { Grid } from '@/components/layout/Grid';
+import { Section } from '@/components/layout/Section';
+import { Surface } from '@/components/layout/Surface';
+import { useFleetListContext } from '@/contexts/FleetList.context';
+import { MultiSelect, Select, TextInput } from '@mantine/core';
+import { IconBike, IconBolt, IconCreditCard, IconDisabled2, IconHomeHeart, IconSearch, IconTriangle, IconWifi } from '@tabler/icons-react';
+import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
+
+/* * */
+
+export function FleetListToolbar() {
+	//
+
+	//
+	// A. Setup variables
+
+	const t = useTranslations('fleet.FleetListToolbar');
+	const optionsLabels = useTranslations('options');
+
+	const fleetListContext = useFleetListContext();
+
+	//
+	// B. Transform data
+
+	const propulsionOptions = useMemo(() => {
+		if (!fleetListContext.data.raw) return [];
+		const allOptionsValues = new Set<string>(fleetListContext.data.raw.map(item => item.propulsion).filter(Boolean).map(String));
+		return Array.from(allOptionsValues).map(value => ({ label: optionsLabels(`VehiclePropulsion.${value}`), value: value })) || [];
+	}, [fleetListContext.data.raw]);
+
+	const agencyOptions = useMemo(() => {
+		if (!fleetListContext.data.raw) return [];
+		const allOptionsValues = new Set<string>(fleetListContext.data.raw.map(item => item.agency_id).filter(Boolean));
+		return Array.from(allOptionsValues).map(value => ({ label: optionsLabels(`Agency.${value}`), value: value })) || [];
+	}, [fleetListContext.data.raw]);
+
+	const makeAndModelOptions = useMemo(() => {
+		if (!fleetListContext.data.raw) return [];
+		const allOptionsMap = new Map<string, Set<string>>();
+		fleetListContext.data.raw.forEach((item) => {
+			if (!item.make || !item.model) return;
+			if (!allOptionsMap.has(item.make)) allOptionsMap.set(item.make, new Set<string>());
+			allOptionsMap.get(item.make)?.add(item.model);
+		});
+		return Array
+			.from(allOptionsMap.entries())
+			.map(([make, models]) => ({
+				group: make,
+				items: Array
+					.from(models)
+					.map(model => ({ label: `${make} - ${model}`, value: `${make}-${model}` }))
+					.sort((a, b) => a.label.localeCompare(b.label)),
+			}))
+			.sort((a, b) => a.group.localeCompare(b.group));
+	}, [fleetListContext.data.raw]);
+
+	//
+	// C. Handle actions
+
+	const handleTextInputChange = ({ currentTarget }) => {
+		fleetListContext.actions.updateFilterBySearch(currentTarget.value);
+	};
+
+	//
+	// D. Render components
+
+	return (
+		<Surface variant="persistent">
+			<Section withGap withPadding>
+				<Grid columns="a" withGap>
+					<TextInput
+						leftSection={<IconSearch />}
+						onChange={handleTextInputChange}
+						placeholder={t('filters.by_search.placeholder')}
+						type="search"
+						value={fleetListContext.filters.by_search}
+					/>
+					<MultiSelect
+						data={agencyOptions}
+						leftSection={<IconHomeHeart />}
+						onChange={fleetListContext.actions.updateFilterByAgency}
+						placeholder={t('filters.by_agency.placeholder')}
+						value={fleetListContext.filters.by_agency ? fleetListContext.filters.by_agency?.split(';') : []}
+						clearable
+						searchable
+					/>
+					<MultiSelect
+						data={propulsionOptions}
+						leftSection={<IconBolt />}
+						onChange={fleetListContext.actions.updateFilterByPropulsion}
+						placeholder={t('filters.by_propulsion.placeholder')}
+						value={fleetListContext.filters.by_propulsion ? fleetListContext.filters.by_propulsion?.split(';') : []}
+						clearable
+						searchable
+					/>
+
+					<Select
+						leftSection={<IconWifi />}
+						onChange={fleetListContext.actions.updateFilterByVehicleState}
+						placeholder={t('filters.by_state.placeholder')}
+						value={fleetListContext.filters.by_vehicle_state}
+						data={[
+							{ label: t('filters.by_state.options.active'), value: 'active' },
+							{ label: t('filters.by_state.options.no_service'), value: 'no_service' },
+							{ label: t('filters.by_state.options.active_1h'), value: 'active_1h' },
+							{ label: t('filters.by_state.options.active_today'), value: 'active_today' },
+							{ label: t('filters.by_state.options.active_7d'), value: 'active_7d' },
+							{ label: t('filters.by_state.options.inactive'), value: 'inactive' },
+							{ label: t('filters.by_state.options.no_data'), value: 'no_data' },
+						]}
+						clearable
+						searchable
+					/>
+				</Grid>
+
+				<ExpandToggle defaultState={!!fleetListContext.filters.by_agency || !!fleetListContext.filters.by_bikes || !!fleetListContext.filters.by_wheelchair || !!fleetListContext.filters.by_make_and_model}>
+					<Grid columns="a" withGap>
+						<Select
+							leftSection={<IconCreditCard />}
+							onChange={fleetListContext.actions.updateFilterByContactless}
+							placeholder={t('filters.by_contactless.placeholder')}
+							value={fleetListContext.filters.by_contactless}
+							data={[
+								{ label: t('filters.by_contactless.options.false'), value: 'false' },
+								{ label: t('filters.by_contactless.options.true'), value: 'true' },
+							]}
+							clearable
+							searchable
+						/>
+						<Select
+							leftSection={<IconDisabled2 />}
+							onChange={fleetListContext.actions.updateFilterByWheelchair}
+							placeholder={t('filters.by_wheelchair.placeholder')}
+							value={fleetListContext.filters.by_wheelchair}
+							data={[
+								{ label: t('filters.by_wheelchair.options.false'), value: 'false' },
+								{ label: t('filters.by_wheelchair.options.true'), value: 'true' },
+							]}
+							clearable
+							searchable
+						/>
+						<Select
+							leftSection={<IconBike />}
+							onChange={fleetListContext.actions.updateFilterByBikes}
+							placeholder={t('filters.by_bikes.placeholder')}
+							value={fleetListContext.filters.by_bikes}
+							data={[
+								{ label: t('filters.by_bikes.options.false'), value: 'false' },
+								{ label: t('filters.by_bikes.options.true'), value: 'true' },
+							]}
+							clearable
+							searchable
+						/>
+						<MultiSelect
+							data={makeAndModelOptions}
+							leftSection={<IconTriangle />}
+							onChange={fleetListContext.actions.updateFilterByMakeAndModel}
+							placeholder={t('filters.by_make_model.placeholder')}
+							value={fleetListContext.filters.by_make_and_model ? fleetListContext.filters.by_make_and_model?.split(';') : []}
+							clearable
+							searchable
+						/>
+					</Grid>
+				</ExpandToggle>
+				<FoundItemsCounter text={t('found_items_counter', { count: fleetListContext.data.filtered.length })} />
+			</Section>
+		</Surface>
+	);
+
+	//
+}

--- a/apps/frontend/src/components/fleet/FleetListToolbar/index.tsx
+++ b/apps/frontend/src/components/fleet/FleetListToolbar/index.tsx
@@ -55,7 +55,7 @@ export function FleetListToolbar() {
 				group: make,
 				items: Array
 					.from(models)
-					.map(model => ({ label: `${make} - ${model}`, value: `${make}-${model}` }))
+					.map(model => ({ label: `${make} - ${model}`, value: `${make.replaceAll('-', '')}-${model.replaceAll('-', '')}` })) // mercedes-benz becomes mercedesbenz to not break the filter
 					.sort((a, b) => a.label.localeCompare(b.label)),
 			}))
 			.sort((a, b) => a.group.localeCompare(b.group));

--- a/apps/frontend/src/components/fleet/FleetListView/index.tsx
+++ b/apps/frontend/src/components/fleet/FleetListView/index.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+/* * */
+
+import { NoDataLabel } from '@/components/layout/NoDataLabel';
+import { Section } from '@/components/layout/Section';
+import { Surface } from '@/components/layout/Surface';
+import { useFleetListContext } from '@/contexts/FleetList.context';
+import { useTranslations } from 'next-intl';
+
+import { FleetListTable } from '../FleetListTable';
+
+/* * */
+
+export function FleetListView() {
+	const fleetListContext = useFleetListContext();
+	const t = useTranslations('fleet.FleetTable');
+
+	if (!fleetListContext.data.filtered.length) {
+		return (
+			<Surface variant="persistent" forceOverflow>
+				<Section>
+					<NoDataLabel text={t('no_data')} withMinHeight />
+				</Section>
+			</Surface>
+		);
+	}
+
+	return (
+		<Surface variant="persistent" forceOverflow>
+			<Section>
+				<FleetListTable />
+			</Section>
+		</Surface>
+	);
+}

--- a/apps/frontend/src/components/fleet/FleetMetrics/index.tsx
+++ b/apps/frontend/src/components/fleet/FleetMetrics/index.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { LiveIcon } from '@/components/common/LiveIcon';
+import { Section } from '@/components/layout/Section';
+import { Surface } from '@/components/layout/Surface';
+import { useFleetContext } from '@/contexts/Fleet.context';
+import { VehiclePropulsion } from '@carrismetropolitana/api-types/vehicles';
+import { Skeleton } from '@mantine/core';
+import { IconBolt } from '@tabler/icons-react';
+import { useTranslations } from 'next-intl';
+
+import styles from './styles.module.css';
+
+export function FleetMetrics() {
+	const t = useTranslations('fleet.FleetMetrics');
+
+	const fleetContext = useFleetContext();
+
+	const activeVehicles = fleetContext.actions.getAllActiveVehicles().length;
+	const electricVehicles = fleetContext.actions.getAllVehiclesByFilter({ propulsion: VehiclePropulsion.electricity }).length;
+	const totalVehicles = fleetContext.actions.getAllVehicles().length;
+
+	return (
+		<Surface>
+			<Section withGap withPadding>
+				<div className={styles.metricsWrapper}>
+					<div className={styles.infoWrapper}>
+						<div className={styles.bigNumberWrapper}>
+							<h1 className={styles.bigNumber} style={{ color: 'var(--color-brand)' }}>{t('total_circulating', { count: activeVehicles })}</h1>
+							<LiveIcon className={styles.liveIcon} color="var(--color-brand)" />
+						</div>
+						<h3 className={styles.title}>{t('total_circulating_title')}</h3>
+						{fleetContext.flags.is_loading && <Skeleton height={16} width={200} />}
+						{!fleetContext.flags.is_loading && <p className={styles.description}>{t('total_circulating_footer', { percentage: ((activeVehicles / totalVehicles) * 100).toFixed(1) })}</p>}
+					</div>
+					<div className={styles.infoWrapper}>
+						<div className={styles.bigNumberWrapper}>
+							<h1 className={styles.bigNumber} style={{ color: 'var(--color-brand)' }}>{t('total_electric', { count: electricVehicles })}</h1>
+							<IconBolt color="var(--color-brand)" />
+						</div>
+						<h3 className={styles.title}>{t('total_electric_title')}</h3>
+						{fleetContext.flags.is_loading && <Skeleton height={16} width={400} />}
+						{!fleetContext.flags.is_loading && <p className={styles.description}>{t('total_electric_footer', { percentage: ((electricVehicles / totalVehicles) * 100).toFixed(1) })}</p>}
+					</div>
+				</div>
+			</Section>
+		</Surface>
+	);
+}

--- a/apps/frontend/src/components/fleet/FleetMetrics/styles.module.css
+++ b/apps/frontend/src/components/fleet/FleetMetrics/styles.module.css
@@ -1,0 +1,82 @@
+.container{
+    display: flex;
+    flex-direction: column;
+    place-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;   
+    padding: 20px;
+    text-align: center;
+    background-color: var(--color-system-background-100);
+    border: 1px solid 	var(--color-system-border-200);
+    border-radius: 20px;
+}
+
+/* * */
+/* WRAPPERS */
+
+.metricsWrapper {
+    display: flex;
+    flex-direction: row;
+    gap: var(--size-spacing-10);
+    width: 100%;
+}
+
+.infoWrapper {
+	display: flex;
+    flex-grow: 1;
+	flex-direction: column;
+	gap: var(--size-spacing-5);
+    width: 50%;
+}
+
+
+.bigNumberWrapper {
+	display: flex;
+	flex-direction: row;
+	gap: var(--size-spacing-10);
+	align-items: flex-start;
+}
+
+.bigNumber {
+    font-size: 60px;
+    font-weight: var(--font-weight-bold);
+	line-height: 1;
+}
+
+.liveIcon {
+    margin-top: var(--size-spacing-5);
+}
+
+.title {
+	font-size: 18px;
+	font-weight: var(--font-weight-bold);
+	color: var(--color-system-text-100)
+}
+
+.description {
+	font-size: 12px;
+	font-weight: var(--font-weight-medium);
+	line-height: 1.6;
+	color: var(--color-system-text-200);
+}
+
+.footnote {
+	font-size: 12px;
+	font-weight: var(--font-weight-medium);
+	line-height: 1.6;
+	color: var(--color-system-text-300);
+}
+
+@media (width < 1000px) {
+	.metricsWrapper {
+        display: flex;
+        flex-direction: column;
+        gap: var(--size-spacing-10);
+        width: 100%;
+    }
+
+    .infoWrapper {
+	    width: 100%;
+    }
+}

--- a/apps/frontend/src/components/fleet/FleetPage/index.tsx
+++ b/apps/frontend/src/components/fleet/FleetPage/index.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+/* * */
+
+import { FleetListToolbar } from '@/components/fleet/FleetListToolbar';
+import { FleetListView } from '@/components/fleet/FleetListView';
+import { FleetMetrics } from '@/components/fleet/FleetMetrics';
+import { GridNav } from '@/components/layout/GridNav';
+import { Section } from '@/components/layout/Section';
+import { Surface } from '@/components/layout/Surface';
+import { URLS } from '@/settings/urls.settings';
+import { IconCode, IconDownload, IconMap, IconMessageReport } from '@tabler/icons-react';
+import { useTranslations } from 'next-intl';
+
+import styles from './styles.module.css';
+
+export function FleetPage() {
+	const t = useTranslations('fleet.FleetPage');
+
+	const FLEET_LINKS = [
+		{ _id: 'issues', description: t('links.issues_description'), href: URLS.repos.datasets + '/issues', icon: <IconMessageReport />, label: t('links.issues') },
+		{ _id: 'download_metadata', description: t('links.download_metadata_description'), href: URLS.repos.datasets + '/blob/latest/vehicles/vehicles.csv', icon: <IconDownload />, label: t('links.download_metadata') },
+		{ _id: 'use_api', description: t('links.use_api_description'), href: URLS.repos.api + '?tab=readme-ov-file#vehicles', icon: <IconCode />, label: t('links.use_api') },
+		{ _id: 'view_map', description: t('links.view_map_description'), href: '/vehicles', icon: <IconMap />, label: t('links.view_map') },
+	];
+
+	return (
+		<>
+			<Surface>
+				<Section heading={t('heading')} subheading={t('subheading')}>
+					<GridNav className={styles.gridNavOverride} items={FLEET_LINKS} />
+				</Section>
+			</Surface>
+			<FleetMetrics />
+			<FleetListToolbar />
+			<FleetListView />
+		</>
+	);
+}

--- a/apps/frontend/src/components/fleet/FleetPage/styles.module.css
+++ b/apps/frontend/src/components/fleet/FleetPage/styles.module.css
@@ -1,0 +1,18 @@
+.subheading {
+    width: 100%;
+    font-size: 14px;
+    font-weight: 400;
+    color: var(--color-system-text-200);
+}
+
+.gridNavOverride {
+  grid-template-columns: 1fr;
+}
+
+.text {
+	padding-left: 5px;
+	font-size: 16px;
+	font-weight: var(--font-weight-medium);
+	line-height: 1.6;
+	color: var(--color-system-text-100);
+}

--- a/apps/frontend/src/components/fleet/FleetRow/index.tsx
+++ b/apps/frontend/src/components/fleet/FleetRow/index.tsx
@@ -1,0 +1,172 @@
+/* * */
+
+import type { Vehicle } from '@carrismetropolitana/api-types/vehicles';
+
+import { LiveIcon } from '@/components/common/LiveIcon';
+import { LineBadge } from '@/components/lines/LineBadge';
+import { useFleetContext } from '@/contexts/Fleet.context';
+import { Skeleton } from '@mantine/core';
+import { IconCircleCheck, IconCircleX, IconCreditCard, IconWifiOff } from '@tabler/icons-react';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+
+import styles from './styles.module.css';
+
+/* * */
+
+interface Props {
+	isHeader?: boolean
+	vehicleData?: Vehicle
+	width?: number
+}
+
+function useWindowWidth() {
+	const [width, setWidth] = useState(window.innerWidth);
+
+	useEffect(() => {
+		const handler = () => setWidth(window.innerWidth);
+		window.addEventListener('resize', handler);
+		return () => window.removeEventListener('resize', handler);
+	}, []);
+
+	return width;
+}
+
+/* * */
+
+function getOperatorFromAgencyId(agency_id) {
+	switch (agency_id) {
+		case '41':
+			return 'V. Alvorada';
+		case '42':
+			return 'RL';
+		case '43':
+			return 'TST';
+		case '44':
+			return 'Alsa Todi';
+		default:
+			return 'ERRO';
+	}
+}
+
+export function FleetRow({ isHeader, vehicleData }: Props) {
+	//
+
+	const t = useTranslations('fleet');
+	const propulsionT = useTranslations('options.VehiclePropulsion');
+
+	const collumns = [
+		{
+			key: 'id',
+			label: t('FleetTable.header.fleetId'),
+			width: '80px',
+		},
+		{
+			key: 'agency',
+			label: t('FleetTable.header.agency'),
+			minWidth: 651, // 650px and lower is when the website's layout changes considerably, losing the "floating" surfaces
+			width: '100px',
+		},
+		{
+			key: 'contactless',
+			label: (<IconCreditCard />),
+			width: '50px',
+		},
+		{
+			key: 'propulsion',
+			label: t('FleetTable.header.propulsion'),
+			minWidth: 550,
+			width: '100px',
+		},
+		{
+			key: 'model',
+			label: t('FleetTable.header.model'),
+			minWidth: 1000,
+			width: '300px',
+		},
+		{
+			key: 'capacity',
+			label: t('FleetTable.header.capacity'),
+			minWidth: 1200,
+			width: '150px',
+		},
+		{
+			key: 'status',
+			label: t('FleetTable.header.status'),
+			width: '1fr',
+		},
+	];
+
+	const fleetContext = useFleetContext();
+
+	function getVehicleStatus(vehicleData: Vehicle) {
+		const tripId = vehicleData.trip_id;
+		if (!tripId) return (<div className={styles.statusDiv}><IconWifiOff color="red" /><span>{t('FleetTable.status.no_data')}</span></div>);
+		const lastPing = vehicleData.timestamp;
+		const now = Date.now() / 1000;
+
+		// If last ping is from over 7 days ago
+		if (lastPing < (now - 604_800)) {
+			return (<span>{t('FleetTable.status.inactive')}</span>);
+		}
+
+		const currentOperationalDate = fleetContext.actions.getOperationalDate().getTime() / 1000;
+
+		if (lastPing < (currentOperationalDate)) {
+			return (<div className={[styles.statusDiv, styles.pastDeparture].join(' ')}><span>{t('FleetTable.status.activeWeek', { days: Math.floor((currentOperationalDate - lastPing) / 86_400) + 1 })}</span></div>);
+		}
+
+		if (lastPing > currentOperationalDate && lastPing < (now - 3600)) return (<div className={[styles.statusDiv, styles.pastDeparture].join(' ')}><span>{t('FleetTable.status.activeToday', { hours: Math.floor((now - lastPing) / 3600) })}</span><LineBadge lineId={vehicleData.line_id || 'CP'} shortName={(vehicleData.line_id === '1998' || vehicleData.line_id === '1999') ? 'CP' : vehicleData.line_id} /></div>);
+
+		if (lastPing > currentOperationalDate && lastPing < (now - 120)) return (<div className={[styles.statusDiv, styles.pastDeparture].join(' ')}><span>{t('FleetTable.status.activeHour', { mins: Math.floor((now - lastPing) / 60) })}</span><LineBadge lineId={vehicleData.line_id || 'CP'} shortName={(vehicleData.line_id === '1998' || vehicleData.line_id === '1999') ? 'CP' : vehicleData.line_id} /></div>);
+
+		return (<div className={styles.statusDiv}><LiveIcon /><span>{t('FleetTable.status.activeNow')}</span><LineBadge lineId={vehicleData.line_id || 'CP'} shortName={(vehicleData.line_id === '1998' || vehicleData.line_id === '1999') ? 'CP' : vehicleData.line_id} /></div>);
+	}
+
+	const width = useWindowWidth();
+	const visibleColumns = collumns.filter(column => (column.minWidth ? column.minWidth <= width : true));
+
+	if (isHeader) {
+		return (
+			<div className={styles.row} style={{ gridTemplateColumns: visibleColumns.map(col => col.width).join(' ') }}>
+				{visibleColumns.map(col => (<div key={col.key}>{col.label}</div>))}
+			</div>
+		);
+	}
+
+	if (vehicleData) {
+		const [showInfo, setShowInfo] = useState(false);
+		function toggleInfo() {
+			setShowInfo(!showInfo);
+		}
+
+		return (
+			<>
+				<div className={styles.row} onClick={toggleInfo} style={{ gridTemplateColumns: visibleColumns.map(col => col.width).join(' ') }}>
+					{visibleColumns.find(col => col.key === 'id') && <div>{vehicleData.id}</div>}
+					{visibleColumns.find(col => col.key === 'agency') && <div>{getOperatorFromAgencyId(vehicleData.agency_id)}</div>}
+					{visibleColumns.find(col => col.key === 'contactless') && <div>{vehicleData.contactless ? <IconCircleCheck color="green" /> : <IconCircleX color="red" />}</div>}
+					{visibleColumns.find(col => col.key === 'propulsion') && <div>{vehicleData.propulsion ? propulsionT(`${vehicleData.propulsion}`) : 'N/A'}</div>}
+					{visibleColumns.find(col => col.key === 'model') && <div>{(vehicleData.make ? (vehicleData.make + ' - ' + vehicleData.model) : t('FleetTable.unknown'))}</div>}
+					{visibleColumns.find(col => col.key === 'capacity') && <div>{vehicleData.capacity_total ? `${vehicleData.capacity_total} (${vehicleData.capacity_seated}+${vehicleData.capacity_standing})` : t('FleetTable.unknown')}</div>}
+					{visibleColumns.find(col => col.key === 'status') && <div>{getVehicleStatus(vehicleData)}</div>}
+				</div>
+
+			</>
+		);
+	}
+
+	return (
+		<div className={styles.row} style={{ gridTemplateColumns: collumns.map(col => col.width).join(' ') }}>
+			<div><Skeleton height={24} width={50} /></div>
+			<div><Skeleton height={24} width={50} /></div>
+			<div><Skeleton height={24} width={50} /></div>
+			<div><Skeleton height={24} width={50} /></div>
+			<div><Skeleton height={24} width={50} /></div>
+			<div><Skeleton height={24} width={50} /></div>
+			<div><Skeleton height={24} width={50} /></div>
+		</div>
+	);
+
+	//
+}

--- a/apps/frontend/src/components/fleet/FleetRow/styles.module.css
+++ b/apps/frontend/src/components/fleet/FleetRow/styles.module.css
@@ -1,0 +1,47 @@
+.row {
+	display: grid;
+	flex-direction: row;
+	grid-template-columns: max-content 1fr 1fr;
+	gap: var(--size-spacing-10); 
+  	align-items: center;
+	width: 100%;
+  	height: 40px;
+	padding: var(--size-spacing-10);
+	text-align: center;
+  	border-bottom: 1px solid var(--color-system-text-300);
+}
+
+.row div {
+	overflow: hidden;
+  	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.container {
+	display: flex;
+	flex-direction: row;
+	gap: var(--size-spacing-10);
+	align-items: center;
+	justify-content: flex-start;
+}
+
+.statusDiv {
+	display: flex;
+	flex-direction: row;
+	gap: var(--size-spacing-5);
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	text-align: center;
+}
+
+.pastDeparture span {
+	font-style: italic;
+	color: var(--color-system-text-200);
+}
+
+.vehicleInfo {
+	display: none;
+	width: 100%;
+	background-color: red;
+}

--- a/apps/frontend/src/contexts/Fleet.context.tsx
+++ b/apps/frontend/src/contexts/Fleet.context.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+/* * */
+
+import { type Vehicle } from '@carrismetropolitana/api-types/vehicles';
+import { getPublicVariable } from '@carrismetropolitana/website-shared-settings';
+import { createContext, useContext, useMemo } from 'react';
+import useSWR from 'swr';
+
+/* * */
+
+interface FleetContextState {
+	actions: {
+		getAllActiveVehicles: () => undefined | Vehicle[]
+		getAllVehicles: () => undefined | Vehicle[]
+		getAllVehiclesByFilter: (filters: Partial<Vehicle>) => undefined | Vehicle[]
+		getOperationalDate: () => Date
+	}
+	data: {
+		vehicles: Vehicle[]
+	}
+	flags: {
+		is_loading: boolean
+	}
+}
+
+/* * */
+
+const FleetContext = createContext<FleetContextState | undefined>(undefined);
+
+export function useFleetContext() {
+	const context = useContext(FleetContext);
+	if (!context) {
+		throw new Error('useFleetContext must be used within a FleetContextProvider');
+	}
+	return context;
+}
+
+/* * */
+
+export const FleetContextProvider = ({ children }) => {
+	//
+
+	//
+	// A. Fetch data
+
+	const { data: fetchedVehiclesData, isLoading: allVehiclesLoading } = useSWR<Vehicle[], Error>(`${getPublicVariable('api_url')}/vehicles`, { refreshInterval: 5000 }); // 5 seconds
+
+	const allVehiclesData = useMemo(() => {
+		if (!fetchedVehiclesData) return [];
+		return fetchedVehiclesData; // .filter((vehicle: Vehicle) => (vehicle.timestamp ?? 0) > now - 180); // We want ALL vehicles for our fleet page. Even those not in service/with no data
+	}, [fetchedVehiclesData]);
+
+	const allActiveVehiclesData = useMemo(() => {
+		if (!fetchedVehiclesData) return [];
+		const now = Date.now() / 1000;
+		return fetchedVehiclesData.filter((vehicle: Vehicle) => (vehicle.timestamp ?? 0) > now - 180);
+	}, [fetchedVehiclesData]);
+
+	//
+	// B. Handle actions
+
+	const getAllVehicles = (): undefined | Vehicle[] => {
+		return allVehiclesData;
+	};
+
+	const getAllActiveVehicles = (): undefined | Vehicle[] => {
+		return allActiveVehiclesData;
+	};
+
+	const getAllVehiclesByFilter = (filters: Partial<Vehicle>): undefined | Vehicle[] => {
+		return allVehiclesData.filter(vehicle =>
+			(Object.keys(filters) as (keyof Vehicle)[])
+				.every(filter => vehicle[filter] === filters[filter]),
+		);
+	};
+
+	const getOperationalDate = (): Date => {
+		const currentOperationalDate = new Date(new Date().toLocaleString('en-US', { timeZone: 'Europe/Lisbon' }));
+
+		if (currentOperationalDate.getHours() < 4) {
+			currentOperationalDate.setDate(currentOperationalDate.getDate() - 1); // The period between 00h00 and 03h59 falls under the previous operational date
+		}
+
+		currentOperationalDate.setHours(4, 0, 0, 0);
+
+		return currentOperationalDate;
+	};
+
+	//
+	// C. Define context value
+
+	const contextValue: FleetContextState = {
+		actions: {
+			getAllActiveVehicles,
+			getAllVehicles,
+			getAllVehiclesByFilter,
+			getOperationalDate,
+		},
+		data: {
+			vehicles: allVehiclesData || [],
+		},
+		flags: {
+			is_loading: allVehiclesLoading,
+		},
+	};
+
+	//
+	// D. Render components
+
+	return (
+		<FleetContext.Provider value={contextValue}>
+			{children}
+		</FleetContext.Provider>
+	);
+
+	//
+};

--- a/apps/frontend/src/contexts/FleetList.context.tsx
+++ b/apps/frontend/src/contexts/FleetList.context.tsx
@@ -147,9 +147,9 @@ export const FleetListContextProvider = ({ children }) => {
 			const makeModelValues = filterByMakeAndModelState.split(';').filter(Boolean);
 			filterResult = filterResult.filter((item) => {
 				return makeModelValues.some((val) => {
-					const [makeFilter, modelFilter] = val.split('-').map(s => s.trim().toLowerCase());
-					const itemMake = item.make?.toLowerCase() || '';
-					const itemModel = item.model?.toLowerCase() || '';
+					const [makeFilter, modelFilter] = val.split('-').map(s => s.trim().toLowerCase()); // Mercedes-Benz has a dash in the middle. Make/Model is formated as 'MAKE - MODEL' so its safe to include a space before/after the check
+					const itemMake = item.make?.toLowerCase().replaceAll('-', '') || ''; // discards dashes in the make/model, to be inline with the makeFilter/modelFilter.
+					const itemModel = item.model?.toLowerCase().replaceAll('-', '') || '';
 					return itemMake.includes(makeFilter) && itemModel.includes(modelFilter);
 				});
 			});

--- a/apps/frontend/src/contexts/FleetList.context.tsx
+++ b/apps/frontend/src/contexts/FleetList.context.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+/* * */
+
+import { useFleetContext } from '@/contexts//Fleet.context';
+import { Vehicle } from '@carrismetropolitana/api-types/vehicles';
+import { useQueryState } from 'nuqs';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+/* * */
+
+interface FleetListContextState {
+	actions: {
+		updateFilterByAgency: (values: string[]) => void
+		updateFilterByBikes: (value: string) => void
+		updateFilterByContactless: (value: string) => void
+		updateFilterByMakeAndModel: (values: string[]) => void
+		updateFilterByPropulsion: (values: string[]) => void
+		updateFilterBySearch: (value: string) => void
+		updateFilterByVehicleState: (value: string) => void
+		updateFilterByWheelchair: (value: string) => void
+		updateSelectedVehicle: (value: null | string) => void
+	}
+	data: {
+		filtered: Vehicle[]
+		raw: Vehicle[]
+		selected: null | Vehicle
+	}
+	filters: {
+		by_agency: null | string
+		by_bikes: null | string
+		by_contactless: null | string
+		by_make_and_model: null | string
+		by_propulsion: null | string
+		by_search: string
+		by_vehicle_state: null | string
+		by_wheelchair: null | string
+		selected_vehicle: null | string
+	}
+	flags: {
+		is_loading: boolean
+	}
+}
+
+const FleetListContext = createContext<FleetListContextState | undefined>(undefined);
+
+export function useFleetListContext() {
+	const context = useContext(FleetListContext);
+	if (!context) {
+		throw new Error('useFleetListContext must be used within a VehiclesListContext');
+	}
+	return context;
+}
+
+export const FleetListContextProvider = ({ children }) => {
+	//
+
+	//
+	// A. Setup variables
+
+	const fleetContext = useFleetContext();
+
+	const [dataFilteredState, setDataFilteredState] = useState<FleetListContextState['data']['filtered']>([]);
+	const [dataSelectedState, setDataSelectedState] = useState<FleetListContextState['data']['selected']>(null);
+
+	const [filterByWheelchairState, setFilterByWheelchairState] = useQueryState('by_wheelchair', { clearOnDefault: true });
+	const [filterByAgencyState, setFilterByAgencyState] = useQueryState('by_agency', { clearOnDefault: true });
+	const [filterByBikesState, setByBikesState] = useQueryState('by_bikes', { clearOnDefault: true });
+	const [filterByContactlessState, setByContactlessState] = useQueryState('by_contactless', { clearOnDefault: true });
+	const [filterByMakeAndModelState, setFilterByMakeAndModelState] = useQueryState('by_make_and_model', { clearOnDefault: true });
+	const [filterBySearchState, setFilterBySearchState] = useQueryState('by_search', { clearOnDefault: true, defaultValue: '' });
+	const [filterByVehicleState, setFilterByVehicleState] = useQueryState('by_vehicle_state', { clearOnDefault: true, defaultValue: '' });
+
+	const [filterByPropulsionState, setFilterByPropulsionState] = useQueryState('by_propulsion', { clearOnDefault: true });
+
+	//
+	// C. Transform data
+
+	const applyFiltersToData = () => {
+		//
+
+		let filterResult = fleetContext.data.vehicles || [];
+
+		// Apply the user filters
+
+		const nowInUnixSeconds = new Date().getTime() / 1000;
+
+		const operationalDayInUnixSeconds = fleetContext.actions.getOperationalDate().getTime() / 1000;
+
+		if (filterByVehicleState) {
+			switch (filterByVehicleState) {
+				case 'active':
+					filterResult = filterResult.filter(item => item.timestamp && nowInUnixSeconds - item.timestamp < 120);
+					break;
+				case 'active_1h':
+					filterResult = filterResult.filter(item => item.timestamp && nowInUnixSeconds - item.timestamp < 3600);
+					break;
+				case 'active_7d':
+					filterResult = filterResult.filter(item => item.timestamp && nowInUnixSeconds - item.timestamp < 604_800);
+					break;
+				case 'active_today':
+					filterResult = filterResult.filter(item => item.timestamp && item.timestamp >= operationalDayInUnixSeconds);
+					break;
+				case 'inactive':
+					filterResult = filterResult.filter(item => !item.trip_id || (item.timestamp && nowInUnixSeconds - item.timestamp >= 604_800));
+					break;
+				case 'no_data':
+					filterResult = filterResult.filter(item => !item.trip_id);
+					break;
+				case 'no_service':
+					filterResult = filterResult.filter(item => item.timestamp && nowInUnixSeconds - item.timestamp >= 120);
+					break;
+			}
+		}
+
+		if (filterBySearchState) {
+			filterResult = filterResult.filter((item) => {
+				const matchedVehicleId = item.id?.toLowerCase().includes(filterBySearchState.toLowerCase());
+				const matchedLicensePlate = item.license_plate?.toLowerCase().includes(filterBySearchState.toLowerCase());
+				return matchedVehicleId || matchedLicensePlate;
+			});
+		}
+
+		if (filterByBikesState) {
+			filterResult = filterResult.filter(item => item.bikes_allowed?.toString() === filterByBikesState);
+		}
+
+		if (filterByContactlessState) {
+			filterResult = filterResult.filter(item => (item.contactless || false).toString() === filterByContactlessState);
+		}
+
+		if (filterByWheelchairState) {
+			filterResult = filterResult.filter(item => item.wheelchair_accessible?.toString() === filterByWheelchairState);
+		}
+
+		if (filterByPropulsionState) {
+			const propulsionValues = filterByPropulsionState.split(';').filter(Boolean);
+			filterResult = filterResult.filter(item => item.propulsion && propulsionValues.includes(item.propulsion));
+		}
+
+		if (filterByAgencyState) {
+			const agencyValues = filterByAgencyState.split(';').filter(Boolean);
+			filterResult = filterResult.filter(item => agencyValues.includes(item.agency_id.toString()));
+		}
+
+		if (filterByMakeAndModelState) {
+			const makeModelValues = filterByMakeAndModelState.split(';').filter(Boolean);
+			filterResult = filterResult.filter((item) => {
+				return makeModelValues.some((val) => {
+					const [makeFilter, modelFilter] = val.split('-').map(s => s.trim().toLowerCase());
+					const itemMake = item.make?.toLowerCase() || '';
+					const itemModel = item.model?.toLowerCase() || '';
+					return itemMake.includes(makeFilter) && itemModel.includes(modelFilter);
+				});
+			});
+		}
+
+		return filterResult;
+
+		//
+	};
+
+	useEffect(() => {
+		const filteredVehicles = applyFiltersToData();
+		setDataFilteredState(filteredVehicles);
+	}, [filterBySearchState, filterByAgencyState, filterByBikesState, filterByVehicleState, filterByContactlessState, filterByMakeAndModelState, filterByPropulsionState, filterByWheelchairState, fleetContext.data.vehicles]);
+
+	//
+	// D. Handle actions
+
+	const updateFilterBySearch = (value: string) => {
+		setFilterBySearchState(value);
+	};
+
+	const updateFilterByAgency = (values: string[]) => {
+		if (values.length === 0) setFilterByAgencyState(null);
+		else setFilterByAgencyState(values.sort((a, b) => a.localeCompare(b)).join(';'));
+	};
+
+	const updateFilterByBikes = (value: string) => {
+		setByBikesState(value);
+	};
+
+	const updateFilterByContactless = (value: string) => {
+		setByContactlessState(value);
+	};
+
+	const updateFilterByWheelchair = (value: string) => {
+		setFilterByWheelchairState(value);
+	};
+
+	const updateFilterByMakeAndModel = (values: string[]) => {
+		if (values.length === 0) setFilterByMakeAndModelState(null);
+		else setFilterByMakeAndModelState(values.sort((a, b) => a.localeCompare(b)).join(';'));
+	};
+
+	const updateFilterByPropulsion = (values: string[]) => {
+		if (values.length === 0) setFilterByPropulsionState(null);
+		else setFilterByPropulsionState(values.sort((a, b) => a.localeCompare(b)).join(';'));
+	};
+
+	const updateSelectedVehicle = (vehicleId: null | string) => {
+		if (!vehicleId) setDataSelectedState(null);
+		if (!fleetContext.data.vehicles) return;
+		const foundVehicleData = fleetContext.data.vehicles.find(item => item.id === vehicleId);
+		setDataSelectedState(foundVehicleData || null);
+	};
+
+	const updateFilterByVehicleState = (value: string) => {
+		setFilterByVehicleState(value || null);
+	};
+
+	useEffect(() => {
+		if (!dataSelectedState) return;
+		updateSelectedVehicle(dataSelectedState.id);
+	}, [fleetContext.data.vehicles, dataSelectedState]);
+
+	//
+	// E. Define context value
+
+	const contextValue: FleetListContextState = {
+		actions: {
+			updateFilterByAgency,
+			updateFilterByBikes,
+			updateFilterByContactless,
+			updateFilterByMakeAndModel,
+			updateFilterByPropulsion,
+			updateFilterBySearch,
+			updateFilterByVehicleState,
+			updateFilterByWheelchair,
+			updateSelectedVehicle,
+		},
+		data: {
+			filtered: dataFilteredState,
+			raw: fleetContext.data.vehicles || [],
+			selected: dataSelectedState,
+		},
+		filters: {
+			by_agency: filterByAgencyState,
+			by_bikes: filterByBikesState,
+			by_contactless: filterByContactlessState,
+			by_make_and_model: filterByMakeAndModelState,
+			by_propulsion: filterByPropulsionState,
+			by_search: filterBySearchState,
+			by_vehicle_state: filterByVehicleState,
+			by_wheelchair: filterByWheelchairState,
+			selected_vehicle: dataSelectedState?.id || null,
+		},
+		flags: {
+			is_loading: fleetContext.flags.is_loading,
+		},
+	};
+
+	//
+	// F. Render components
+
+	return (
+		<FleetListContext.Provider value={contextValue}>
+			{children}
+		</FleetListContext.Provider>
+	);
+
+	//
+};

--- a/apps/frontend/src/contexts/VehiclesList.context.tsx
+++ b/apps/frontend/src/contexts/VehiclesList.context.tsx
@@ -13,6 +13,7 @@ interface VehiclesListContextState {
 	actions: {
 		updateFilterByAgency: (values: string[]) => void
 		updateFilterByBikes: (value: string) => void
+		updateFilterByContactless: (value: string) => void
 		updateFilterByMakeAndModel: (values: string[]) => void
 		updateFilterByPropulsion: (values: string[]) => void
 		updateFilterBySearch: (value: string) => void
@@ -27,6 +28,7 @@ interface VehiclesListContextState {
 	filters: {
 		by_agency: null | string
 		by_bikes: null | string
+		by_contactless: null | string
 		by_make_and_model: null | string
 		by_propulsion: null | string
 		by_search: string
@@ -62,6 +64,7 @@ export const VehiclesListContextProvider = ({ children }) => {
 	const [filterByWheelchairState, setFilterByWheelchairState] = useQueryState('by_wheelchair', { clearOnDefault: true });
 	const [filterByAgencyState, setFilterByAgencyState] = useQueryState('by_agency', { clearOnDefault: true });
 	const [filterByBikesState, setByBikesState] = useQueryState('by_bikes', { clearOnDefault: true });
+	const [filterByContactlessState, setByContactlessState] = useQueryState('by_contactless', { clearOnDefault: true });
 	const [filterByMakeAndModelState, setFilterByMakeAndModelState] = useQueryState('by_make_and_model', { clearOnDefault: true });
 	const [filterBySearchState, setFilterBySearchState] = useQueryState('by_search', { clearOnDefault: true, defaultValue: '' });
 	const [filterByPropulsionState, setFilterByPropulsionState] = useQueryState('by_propulsion', { clearOnDefault: true });
@@ -93,6 +96,10 @@ export const VehiclesListContextProvider = ({ children }) => {
 
 		if (filterByBikesState) {
 			filterResult = filterResult.filter(item => item.bikes_allowed?.toString() === filterByBikesState);
+		}
+
+		if (filterByContactlessState) {
+			filterResult = filterResult.filter(item => item.contactless.toString() === filterByContactlessState);
 		}
 
 		if (filterByWheelchairState) {
@@ -129,7 +136,7 @@ export const VehiclesListContextProvider = ({ children }) => {
 	useEffect(() => {
 		const filteredVehicles = applyFiltersToData();
 		setDataFilteredState(filteredVehicles);
-	}, [filterBySearchState, filterByAgencyState, filterByBikesState, filterByMakeAndModelState, filterByPropulsionState, filterByWheelchairState, vehiclesContext.data.vehicles]);
+	}, [filterBySearchState, filterByAgencyState, filterByBikesState, filterByContactlessState, filterByMakeAndModelState, filterByPropulsionState, filterByWheelchairState, vehiclesContext.data.vehicles]);
 
 	//
 	// D. Handle actions
@@ -145,6 +152,10 @@ export const VehiclesListContextProvider = ({ children }) => {
 
 	const updateFilterByBikes = (value: string) => {
 		setByBikesState(value);
+	};
+
+	const updateFilterByContactless = (value: string) => {
+		setByContactlessState(value);
 	};
 
 	const updateFilterByWheelchair = (value: string) => {
@@ -180,6 +191,7 @@ export const VehiclesListContextProvider = ({ children }) => {
 		actions: {
 			updateFilterByAgency,
 			updateFilterByBikes,
+			updateFilterByContactless,
 			updateFilterByMakeAndModel,
 			updateFilterByPropulsion,
 			updateFilterBySearch,
@@ -194,6 +206,7 @@ export const VehiclesListContextProvider = ({ children }) => {
 		filters: {
 			by_agency: filterByAgencyState,
 			by_bikes: filterByBikesState,
+			by_contactless: filterByContactlessState,
 			by_make_and_model: filterByMakeAndModelState,
 			by_propulsion: filterByPropulsionState,
 			by_search: filterBySearchState,

--- a/apps/frontend/src/i18n/translations/en.json
+++ b/apps/frontend/src/i18n/translations/en.json
@@ -622,6 +622,100 @@
 			"subheading": "On this page, you will find answers to the most frequently asked questions about our service. If you need any further clarification, please feel free to contact us."
 		}
 	},
+	"fleet": {
+		"FleetListToolbar": {
+			"filters": {
+				"by_agency": {
+					"placeholder": "All operators"
+				},
+				"by_bikes": {
+					"options": {
+						"false": "No",
+						"true": "Yes"
+					},
+					"placeholder": "Allows Bycicles"
+				},
+				"by_contactless": {
+					"options": {
+						"false": "No",
+						"true": "Yes"
+					},
+					"placeholder": "Supports Contactless"
+				},
+				"by_make_model": {
+					"placeholder": "Brand and Model"
+				},
+				"by_propulsion": {
+					"placeholder": "All kinds of propulsion"
+				},
+				"by_search": {
+					"placeholder": "Search by id, license plate..."
+				},
+				"by_state": {
+					"options": {
+						"active": "Active | In service",
+						"active_1h": "Active in the last hour",
+						"active_7d": "Active in the last 7 days",
+						"active_today": "Active today",
+						"inactive": "Last seen >7 days ago",
+						"no_data": "No data",
+						"no_service": "Not in service"
+					},
+					"placeholder": "Vehicle state"
+				},
+				"by_wheelchair": {
+					"options": {
+						"false": "No",
+						"true": "Yes"
+					},
+					"placeholder": "Allows Reduced Mobility"
+				}
+			},
+			"found_items_counter": "{count, plural, =0 {No vehicle found.} one {Found # vehicle} other {Found # vehicles}}"
+		},
+		"FleetMetrics": {
+			"heading": "Fleet by numbers",
+			"total_circulating": "{count}",
+			"total_circulating_footer": "{percentage}% of our total fleet",
+			"total_circulating_title": "Vehicles circulating on Carris Metropolitana.",
+			"total_electric": "{count}",
+			"total_electric_footer": "{percentage}% of Carris Metropolitana's fleet is environmentally friendly!",
+			"total_electric_title": "Electric vehicles"
+		},
+		"FleetPage": {
+			"heading": "Fleet",
+			"links": {
+				"download_metadata": "Download data",
+				"download_metadata_description": "You can download a list of our fleet as a CSV, following the GTFS (General Transit Feed Specification) specifications. This file contains all of the metadata for existing vehicles.",
+				"issues": "Open an Issue",
+				"issues_description": "If you find any issue in thi spage, please open an Issue on this repository with a suggestion/correction.",
+				"use_api": "API",
+				"use_api_description": "We've made our fleet list available, in real time, through our API. This endpoint, besides returning the vehicles' metadata, also contains information related to the current/past trips.",
+				"view_map": "Map",
+				"view_map_description": "View all active vehicles on an interactive map."
+			},
+			"subheading": "Learn more about our fleet and all vehicles in Carris Metropolitana!"
+		},
+		"FleetTable": {
+			"header": {
+				"agency": "Operator",
+				"capacity": "Capacity",
+				"fleetId": "Fleet #",
+				"model": "Model",
+				"propulsion": "Propulsion",
+				"status": "Status"
+			},
+			"no_data": "No vehicle found",
+			"status": {
+				"activeHour": "{mins, plural, one {Was active # min ago on} other {Was active # mins ago on}}",
+				"activeNow": "Active on",
+				"activeToday": "{hours, plural, one {Was active #h on} other {Was active #h on}}",
+				"activeWeek": "{days, plural, one {Last seen yesterday} other {Last seen # days ago}}",
+				"no_data": "No information available"
+			},
+			"unknown": "Unknown"
+		}
+	},
 	"footer": {
 		"DebugToggle": {
 			"disabled": "Turn on Debug",
@@ -1488,9 +1582,9 @@
 		"VehiclePropulsion": {
 			"diesel": "Diesel",
 			"electricity": "Electricity",
+			"hybrid": "Hybrid",
 			"lpg_auto": "GPL",
-			"natural_gas": "Natural Gas",
-			"hybrid": "Hybrid"
+			"natural_gas": "Natural Gas"
 		}
 	},
 	"periods": {
@@ -2246,7 +2340,7 @@
 	},
 	"vehicles": {
 		"VehiclesList": {
-			"heading": "Vehicles",
+			"heading": "Active Vehicles",
 			"subheading": "Explore our currently active vehicles in realtime and follow the complete operation of Carris Metropolitana."
 		},
 		"VehiclesListDetails": {
@@ -2260,35 +2354,35 @@
 			"wheelchair_accessible": "Reduced mobility"
 		},
 		"VehiclesListInfoBlock": {
-			"heading": "Informação do Veículo"
+			"heading": "Vehicle Information"
 		},
 		"VehiclesListToolbar": {
 			"filters": {
 				"by_agency": {
-					"placeholder": "Todos os operadores"
+					"placeholder": "All operators"
 				},
 				"by_bikes": {
 					"options": {
-						"false": "Não",
-						"true": "Sim"
+						"false": "No",
+						"true": "Yes"
 					},
-					"placeholder": "Permite Bicicletas"
+					"placeholder": "Allows Bycicles"
 				},
 				"by_make_model": {
-					"placeholder": "Marca e Modelo"
+					"placeholder": "Brand and Model"
 				},
 				"by_propulsion": {
-					"placeholder": "Todos os tipos de propulsão"
+					"placeholder": "All kinds of propulsion"
 				},
 				"by_search": {
-					"placeholder": "Pesquisar por id, matrícula..."
+					"placeholder": "Search by id, license plate..."
 				},
 				"by_wheelchair": {
 					"options": {
-						"false": "Não",
-						"true": "Sim"
+						"false": "No",
+						"true": "Yes"
 					},
-					"placeholder": "Permite Mobilidade Reduzida"
+					"placeholder": "Allows Reduced Mobility"
 				}
 			},
 			"found_items_counter": "{count, plural, =0 {No vehicle found.} one {Found # vehicle} other {Found # vehicles}}",

--- a/apps/frontend/src/i18n/translations/pt.json
+++ b/apps/frontend/src/i18n/translations/pt.json
@@ -622,6 +622,100 @@
 			"subheading": "Nesta página encontra respostas às perguntas mais frequentes sobre o nosso serviço. Caso pretenda esclarecimentos adicionais não hesite em falar connosco."
 		}
 	},
+	"fleet": {
+		"FleetListToolbar": {
+			"filters": {
+				"by_agency": {
+					"placeholder": "Todos os operadores"
+				},
+				"by_bikes": {
+					"options": {
+						"false": "Não",
+						"true": "Sim"
+					},
+					"placeholder": "Permite Bicicletas"
+				},
+				"by_contactless": {
+					"options": {
+						"false": "Não",
+						"true": "Sim"
+					},
+					"placeholder": "Suporta Contactless"
+				},
+				"by_make_model": {
+					"placeholder": "Marca e Modelo"
+				},
+				"by_propulsion": {
+					"placeholder": "Todos os tipos de propulsão"
+				},
+				"by_search": {
+					"placeholder": "Pesquisar por id, matrícula..."
+				},
+				"by_state": {
+					"options": {
+						"active": "Ativo | Em serviço",
+						"active_1h": "Circulou na última hora",
+						"active_7d": "Circulou nos últimos 7 dias",
+						"active_today": "Circulou hoje",
+						"inactive": "Circulou à mais de 7 dias",
+						"no_data": "Sem dados",
+						"no_service": "Fora de serviço"
+					},
+					"placeholder": "Estado do veículo"
+				},
+				"by_wheelchair": {
+					"options": {
+						"false": "Não",
+						"true": "Sim"
+					},
+					"placeholder": "Permite Mobilidade Reduzida"
+				}
+			},
+			"found_items_counter": "{count, plural, =0 {Nenhum Veículo encontrado.} one {Encontrado # veículo:} other {Encontrados # veículos:}}"
+		},
+		"FleetMetrics": {
+			"heading": "A frota em números",
+			"total_circulating": "{count}",
+			"total_circulating_footer": "{percentage}% da frota total",
+			"total_circulating_title": "Veículos a realizar serviço na Carris Metropolitana.",
+			"total_electric": "{count}",
+			"total_electric_footer": "{percentage}% da frota da Carris Metropolitana já é amiga do ambiente!",
+			"total_electric_title": "Veículos elétricos"
+		},
+		"FleetPage": {
+			"heading": "Frota",
+			"links": {
+				"download_metadata": "Descarregar dados",
+				"download_metadata_description": "Disponibilizamos a lista de frota em formato CSV, seguindo as específicações de GTFS (General Transit Feed Specification). Este ficheiro contém todos os metadados dos veículos existentes",
+				"issues": "Abrir um Issue",
+				"issues_description": "Caso encontre algum erro nesta página, por favor abra um novo Issue neste repositório com a sugestão de correção.",
+				"use_api": "API",
+				"use_api_description": "Disponibilizamos também a lista de frota, em tempo real, através da API. Este endpoint, para além dos metadados dos veículos, contém informações relativas aos serviços que estejam a efetuar/efetuaram anteriormente.",
+				"view_map": "Mapa",
+				"view_map_description": "Pode ver os veículos que estão atualmente a circular num mapa interativo."
+			},
+			"subheading": "Descubra a nossa frota e aprenda mais sobre os veículos da Carris Metropolitana!"
+		},
+		"FleetTable": {
+			"header": {
+				"agency": "Operador",
+				"capacity": "Capacidade",
+				"fleetId": "# Frota",
+				"model": "Modelo",
+				"propulsion": "Propulsão",
+				"status": "Estado"
+			},
+			"no_data": "Nenhum veículo encontrado",
+			"status": {
+				"activeHour": "{mins, plural, one {Circulou há # min na} other {Circulou há # mins na}}",
+				"activeNow": "A circular na",
+				"activeToday": "{hours, plural, one {Circulou há #h na} other {Circulou há #h na}}",
+				"activeWeek": "{days, plural, one {Circulou ontem} other {Circulou há # dias}}",
+				"no_data": "Sem informações disponíveis"
+			},
+			"unknown": "Desconhecido"
+		}
+	},
 	"footer": {
 		"DebugToggle": {
 			"disabled": "Ligar Debug",
@@ -1478,6 +1572,10 @@
 			"43": "TST",
 			"44": "Alsa Todi"
 		},
+		"Contactless": {
+			"false": "Não",
+			"true": "Sim"
+		},
 		"VehicleEmissionClass": {
 			"euro_1": "EURO 1",
 			"euro_2": "EURO 2",
@@ -1489,9 +1587,9 @@
 		"VehiclePropulsion": {
 			"diesel": "Diesel",
 			"electricity": "Eletricidade",
+			"hybrid": "Híbrido",
 			"lpg_auto": "GPL",
-			"natural_gas": "Gás Natural",
-			"hybrid": "Híbrido"
+			"natural_gas": "Gás Natural"
 		}
 	},
 	"periods": {
@@ -2247,7 +2345,7 @@
 	},
 	"vehicles": {
 		"VehiclesList": {
-			"heading": "Frota",
+			"heading": "Veículos ativos",
 			"subheading": "Descubra os veículos que estão ao serviço neste momento e acompanhe em tempo real a operação completa da CMetropolitana."
 		},
 		"VehiclesListDetails": {

--- a/apps/frontend/src/settings/navigation.settings.tsx
+++ b/apps/frontend/src/settings/navigation.settings.tsx
@@ -45,7 +45,7 @@ export const mainNavigationGroup: NavigationGroup[] = [
 			{ _id: 'open-data', href: '/open-data', icon: <IconPrompt /> },
 			{ _id: 'drivers', href: '/drivers', icon: <IconUserHeart />, target: '_blank' },
 			{ _id: 'about', href: '/about', icon: <IconHomeSpark /> },
-			{ _id: 'vehicles', href: '/vehicles', icon: <IconBus /> },
+			{ _id: 'vehicles', href: '/fleet', icon: <IconBus /> },
 		],
 	},
 

--- a/apps/frontend/src/utils/routes.ts
+++ b/apps/frontend/src/utils/routes.ts
@@ -17,6 +17,12 @@ export const RoutesSupport = Object.freeze({
 		},
 		route: '/faq',
 	},
+	FLEET: {
+		int: {
+			pt: '/frota',
+		},
+		route: '/fleet',
+	},
 	LOST_AND_FOUND: {
 		intl: {
 			pt: '/perdidos-e-achados',


### PR DESCRIPTION
Added a page that displays the entire fleet as a table (that has a variety of filters such as Operator, Propulsion...), from the data available in the /vehicles dataset. 
Additionally, this page also features a metrics section, showing the amount of vehicles that are doing a service at the moment, as well as the amount of electric vehicles (which, I believe, would be a relevant statistic), although this can easily be changed by modifying the FleetMetrics component.

<img width="1775" height="1948" alt="image" src="https://github.com/user-attachments/assets/54f70edb-bdef-45f9-9179-e3fe7ca8b1bb" />
<img width="1765" height="1701" alt="image" src="https://github.com/user-attachments/assets/eb8d5cc4-0d54-47f0-a1a2-8a874ec810dc" />

I believe that this page would be useful as it centralizes the fleet information of all four operators (right now, you'd have to look through a 3rd party archive such as TransportesXXI), making this information more accessible. Additionally, thanks to the filters on this page, anyone can easily look up anything from Carris Metropolitana's fleet (whether it is the amount of vehicles that support contactless, the amount of electric vehicles..., with the option to filter by operator too)

It also has the extra of displaying the status of each vehicle in real time: 
 - If they're active/were active on the current operational day, it'll display the last service done by said vehicle. 
 - If not, it'll display the last time (in days) that this vehicle did any service (or "No information available" if there's no tripId associated with this vehicle)
<img width="1748" height="851" alt="image" src="https://github.com/user-attachments/assets/9b21fed9-61d3-4dc4-aaf2-7d89d3836baf" />
This table automaticly collapses on smaller screens, prioritizing the vehicle's fleet id, propulsion, contactless support and current status

I've also updated the sidebar to point to this page (instead of pointing to /vehicles), as I believe that this page would be more relevant and because the /vehicles page is still easily accessible from this page (4th button on the page's introduction).

The entire page has been translated to english (and I've also updated the translations for the vehicle filters under the /vehicles page, as they were still in Portuguese).

If you have any suggestions or improvements, let me know