### PR TITLE
Fixed make/model filter not working for Mercedes-Benz made vehicles

### DIFF
--- a/apps/frontend/src/components/vehicles/VehiclesListToolbar/index.tsx
+++ b/apps/frontend/src/components/vehicles/VehiclesListToolbar/index.tsx
@@ -54,7 +54,7 @@ export function VehiclesListToolbar() {
 				group: make,
 				items: Array
 					.from(models)
-					.map(model => ({ label: `${make} - ${model}`, value: `${make}-${model}` }))
+					.map(model => ({ label: `${make} - ${model}`, value: `${make.replaceAll('-', '')}-${model.replaceAll('-', '')}` })) // discards dashes from make/model to not break the filter in VehicleFilter - it won't accept any make/model with dashes in it as it separates the make/model by splitting the string where the first '-' is
 					.sort((a, b) => a.label.localeCompare(b.label)),
 			}))
 			.sort((a, b) => a.group.localeCompare(b.group));

--- a/apps/frontend/src/contexts/VehiclesList.context.tsx
+++ b/apps/frontend/src/contexts/VehiclesList.context.tsx
@@ -114,8 +114,8 @@ export const VehiclesListContextProvider = ({ children }) => {
 			filterResult = filterResult.filter((item) => {
 				return makeModelValues.some((val) => {
 					const [makeFilter, modelFilter] = val.split('-').map(s => s.trim().toLowerCase());
-					const itemMake = item.make?.toLowerCase() || '';
-					const itemModel = item.model?.toLowerCase() || '';
+					const itemMake = item.make?.toLowerCase().replaceAll('-', '') || ''; // discards dashes from make/model to be inline with the filter, and as these aren't really necessary. mercedes-benz becomes mercedesbenz and there won't be a model with dashes in its name
+					const itemModel = item.model?.toLowerCase().replaceAll('-', '') || '';
 					return itemMake.includes(makeFilter) && itemModel.includes(modelFilter);
 				});
 			});


### PR DESCRIPTION
Fixed the make/model filter on VehiclesList.context, as it wasn't able to filter any vehicle whose make/model had a dash ('-') by removing the dash from the make/model and redoing the filter to also ignore any dashes on those two fields.
