### PR TITLE
Fix - Selected Store overlaping header

### DIFF
--- a/apps/frontend/src/components/stores/StoresListGroupItem/styles.module.css
+++ b/apps/frontend/src/components/stores/StoresListGroupItem/styles.module.css
@@ -16,7 +16,7 @@
 
 .container.isSelected {
 	position: relative;
-	z-index: 100;
+	z-index: 99;
 	box-shadow: var(--box-shadow-lg);
 }
 


### PR DESCRIPTION
Fixes the selected store row visually overlapping the site header when a list item is in the selected state.