### PR TITLE
Fix - Update alert causes strings

### DIFF
--- a/apps/frontend/src/i18n/translations/en.json
+++ b/apps/frontend/src/i18n/translations/en.json
@@ -189,6 +189,7 @@
 				"HIGH_PASSENGER_LOAD": "High Passenger Load",
 				"MEDICAL_EMERGENCY": "Medical Emergency",
 				"NETWORK_UPDATE": "Network Update",
+				"OTHER_CAUSE": "Other Causes",
 				"POLICE_ACTIVITY": "Police Activity",
 				"PUBLIC_DISORDER": "Public Disorder",
 				"ROAD_ISSUE": "Road Issue",

--- a/apps/frontend/src/i18n/translations/pt.json
+++ b/apps/frontend/src/i18n/translations/pt.json
@@ -190,7 +190,7 @@
 				"HIGH_PASSENGER_LOAD": "Elevada Lotação",
 				"MEDICAL_EMERGENCY": "Emergência Médica",
 				"NETWORK_UPDATE": "Atualização da Rede",
-				"OTHER_CAUSE": "Atualização de Rede",
+				"OTHER_CAUSE": "Outras Causas",
 				"POLICE_ACTIVITY": "Atividade Policial",
 				"PUBLIC_DISORDER": "Desacatos",
 				"ROAD_ISSUE": "Incidente na Via",


### PR DESCRIPTION
## Summary
- Add missing English label for `OTHER_CAUSE` in frontend translations.
- Fix incorrect Portuguese label for `OTHER_CAUSE` from "Atualização da Rede" to "Outras Causas".
- Ensure alert causes render with the correct localized text in both languages.

## Why
The `OTHER_CAUSE` alert reason was either missing (EN) and mapped to the wrong meaning (PT), causing inconsistent and misleading UI labels.