### PR TITLE
Feature/iso 1523 adicionar collection de projetos ao backoffice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ uptime.conf
 # Yalc
 .yalc
 yalc.*
+.cursor/rules/*

--- a/apps/backoffice/payload-types.ts
+++ b/apps/backoffice/payload-types.ts
@@ -102,7 +102,7 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
-  fallbackLocale: null;
+  fallbackLocale: ('false' | 'none' | 'null') | false | null | ('pt-PT' | 'en') | ('pt-PT' | 'en')[];
   globals: {
     'general-status': GeneralStatus;
     'home-slider': HomeSlider;
@@ -113,7 +113,7 @@ export interface Config {
     'home-slider': HomeSliderSelect<false> | HomeSliderSelect<true>;
     settings: SettingsSelect<false> | SettingsSelect<true>;
   };
-  locale: null;
+  locale: 'pt-PT' | 'en';
   user: User;
   jobs: {
     tasks: unknown;

--- a/apps/backoffice/payload-types.ts
+++ b/apps/backoffice/payload-types.ts
@@ -76,6 +76,7 @@ export interface Config {
     users: User;
     'knowledge-base': KnowledgeBase;
     notes: Note;
+    projects: Project;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -92,6 +93,7 @@ export interface Config {
     users: UsersSelect<false> | UsersSelect<true>;
     'knowledge-base': KnowledgeBaseSelect<false> | KnowledgeBaseSelect<true>;
     notes: NotesSelect<false> | NotesSelect<true>;
+    projects: ProjectsSelect<false> | ProjectsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -227,6 +229,10 @@ export interface Article {
      * Breve descrição sobre o autor.
      */
     bio?: string | null;
+    /**
+     * Se este artigo foi escrito por um especialista, lembre-se de marcar para que possa ser entregue conteúdos de especialistas separadamente.
+     */
+    expertAuthor: boolean;
     social?: {
       linkedin?: string | null;
       twitter?: string | null;
@@ -403,6 +409,24 @@ export interface Note {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "projects".
+ */
+export interface Project {
+  id: string;
+  projects?:
+    | {
+        title?: string | null;
+        more_info_url?: string | null;
+        is_unlisted?: boolean | null;
+        featured_image?: (string | null) | Media;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -460,6 +484,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'notes';
         value: string | Note;
+      } | null)
+    | ({
+        relationTo: 'projects';
+        value: string | Project;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -540,6 +568,7 @@ export interface ArticlesSelect<T extends boolean = true> {
         name?: T;
         role?: T;
         bio?: T;
+        expertAuthor?: T;
         social?:
           | T
           | {
@@ -696,6 +725,23 @@ export interface NotesSelect<T extends boolean = true> {
   authors?: T;
   publishedAt?: T;
   updatedAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "projects_select".
+ */
+export interface ProjectsSelect<T extends boolean = true> {
+  projects?:
+    | T
+    | {
+        title?: T;
+        more_info_url?: T;
+        is_unlisted?: T;
+        featured_image?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/apps/backoffice/payload-types.ts
+++ b/apps/backoffice/payload-types.ts
@@ -413,17 +413,22 @@ export interface Note {
  */
 export interface Project {
   id: string;
-  projects?:
+  _order?: string | null;
+  title?: string | null;
+  more_info_url?: string | null;
+  description?: string | null;
+  keywords?:
     | {
-        title?: string | null;
-        more_info_url?: string | null;
-        is_unlisted?: boolean | null;
-        featured_image?: (string | null) | Media;
+        value?: string | null;
         id?: string | null;
       }[]
     | null;
+  is_unlisted?: boolean | null;
+  publishedAt: string;
   updatedAt: string;
+  featured_image?: (string | null) | Media;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -731,17 +736,22 @@ export interface NotesSelect<T extends boolean = true> {
  * via the `definition` "projects_select".
  */
 export interface ProjectsSelect<T extends boolean = true> {
-  projects?:
+  _order?: T;
+  title?: T;
+  more_info_url?: T;
+  description?: T;
+  keywords?:
     | T
     | {
-        title?: T;
-        more_info_url?: T;
-        is_unlisted?: T;
-        featured_image?: T;
+        value?: T;
         id?: T;
       };
+  is_unlisted?: T;
+  publishedAt?: T;
   updatedAt?: T;
+  featured_image?: T;
   createdAt?: T;
+  _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/apps/backoffice/src/app/public-api/projects/[slug]/route.ts
+++ b/apps/backoffice/src/app/public-api/projects/[slug]/route.ts
@@ -1,0 +1,37 @@
+/* * */
+
+import payloadConfig from '@/payload-config';
+import { getPublicHeaders } from '@/utils/get-public-headers';
+import { getPayload } from 'payload';
+
+/* * */
+
+export const GET = async (_request: Request, { params }: { params: Promise<{ slug: string }> }) => {
+	const { slug: identifier } = await params;
+	if (!identifier) {
+		return Response.json({ error: 'Project ID or slug required' }, { headers: getPublicHeaders(null), status: 400 });
+	}
+
+	const payload = await getPayload({ config: payloadConfig });
+
+	const result = await payload.find({
+		collection: 'projects',
+		depth: 2,
+		limit: 1,
+		where: {
+			or: [
+				{ id: { equals: identifier } },
+				{ slug: { equals: identifier } },
+			],
+		},
+	});
+
+	const doc = result.docs[0];
+	if (!doc) {
+		return Response.json({ error: 'Not found' }, { headers: getPublicHeaders(null), status: 404 });
+	}
+
+	return Response.json(doc, {
+		headers: getPublicHeaders(60),
+	});
+};

--- a/apps/backoffice/src/app/public-api/projects/[slug]/route.ts
+++ b/apps/backoffice/src/app/public-api/projects/[slug]/route.ts
@@ -6,8 +6,14 @@ import { getPayload } from 'payload';
 
 /* * */
 
-export const GET = async (_request: Request, { params }: { params: Promise<{ slug: string }> }) => {
+export const GET = async (request: Request, { params }: { params: Promise<{ slug: string }> }) => {
+	const { searchParams } = new URL(request.url);
+	const rawLocale = searchParams.get('locale');
+	const rawFallbackLocale = searchParams.get('fallback-locale');
+	const requestedLocale = rawLocale === 'en' || rawLocale === 'pt-PT' ? rawLocale : undefined;
+	const requestedFallbackLocale = rawFallbackLocale === 'none' || rawFallbackLocale === 'false' ? false : (rawFallbackLocale === 'en' || rawFallbackLocale === 'pt-PT' ? rawFallbackLocale : undefined);
 	const { slug: identifier } = await params;
+
 	if (!identifier) {
 		return Response.json({ error: 'Project ID or slug required' }, { headers: getPublicHeaders(null), status: 400 });
 	}
@@ -17,8 +23,12 @@ export const GET = async (_request: Request, { params }: { params: Promise<{ slu
 	const result = await payload.find({
 		collection: 'projects',
 		depth: 2,
+		draft: false,
+		fallbackLocale: requestedFallbackLocale,
 		limit: 1,
+		locale: requestedLocale,
 		where: {
+			_status: { equals: 'published' },
 			or: [
 				{ id: { equals: identifier } },
 				{ slug: { equals: identifier } },

--- a/apps/backoffice/src/app/public-api/projects/route.ts
+++ b/apps/backoffice/src/app/public-api/projects/route.ts
@@ -6,14 +6,21 @@ import { getPayload } from 'payload';
 
 /* * */
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
 	const payload = await getPayload({ config: payloadConfig });
+	const { searchParams } = new URL(request.url);
+	const rawLocale = searchParams.get('locale');
+	const rawFallbackLocale = searchParams.get('fallback-locale');
+	const requestedLocale = rawLocale === 'en' || rawLocale === 'pt-PT' ? rawLocale : undefined;
+	const requestedFallbackLocale = rawFallbackLocale === 'none' || rawFallbackLocale === 'false' ? false : (rawFallbackLocale === 'en' || rawFallbackLocale === 'pt-PT' ? rawFallbackLocale : undefined);
 
 	const result = await payload.find({
 		collection: 'projects',
 		depth: 2,
 		draft: false,
+		fallbackLocale: requestedFallbackLocale,
 		limit: 0,
+		locale: requestedLocale,
 		sort: '_order',
 		where: {
 			_status: { equals: 'published' },

--- a/apps/backoffice/src/app/public-api/projects/route.ts
+++ b/apps/backoffice/src/app/public-api/projects/route.ts
@@ -1,0 +1,31 @@
+/* * */
+
+import payloadConfig from '@/payload-config';
+import { getPublicHeaders } from '@/utils/get-public-headers';
+import { getPayload } from 'payload';
+
+/* * */
+
+export const GET = async () => {
+	const payload = await getPayload({ config: payloadConfig });
+
+	const result = await payload.find({
+		collection: 'projects',
+		depth: 2,
+		draft: false,
+		limit: 0,
+		sort: '_order',
+		where: {
+			_status: { equals: 'published' },
+			or: [
+				{ is_unlisted: { equals: false } },
+				{ is_unlisted: { equals: undefined } },
+			],
+		},
+	});
+
+	const docs = result.docs ?? [];
+	return Response.json(docs, {
+		headers: getPublicHeaders(180),
+	});
+};

--- a/apps/backoffice/src/payload-config.ts
+++ b/apps/backoffice/src/payload-config.ts
@@ -16,6 +16,7 @@ import { KnowledgeBase } from '@/schemas/KnowledgeBase/collection';
 import { Media } from '@/schemas/Media/collection';
 import { News } from '@/schemas/News/collection';
 import { Notes } from '@/schemas/Notes/collection';
+import { Projects } from '@/schemas/Projects/collection';
 import { Topics } from '@/schemas/Topics/collection';
 import { Users } from '@/schemas/Users/collection';
 
@@ -123,7 +124,7 @@ export default buildConfig({
 		user: 'users',
 	},
 
-	collections: [Campaigns, Articles, CaseStudies, Media, News, Topics, Users, KnowledgeBase, Notes],
+	collections: [Campaigns, Articles, CaseStudies, Media, News, Topics, Users, KnowledgeBase, Notes, Projects],
 
 	csrf: [
 		getPublicVariable('server_url_backoffice').replace(/\/$/, ''),

--- a/apps/backoffice/src/payload-config.ts
+++ b/apps/backoffice/src/payload-config.ts
@@ -155,6 +155,12 @@ export default buildConfig({
 		Settings,
 	],
 
+	localization: {
+		defaultLocale: 'pt-PT',
+		fallback: true,
+		locales: ['pt-PT', 'en'],
+	},
+
 	plugins: [
 		s3Storage({
 			bucket: process.env.OCI_S3_NAMESPACE ?? 'placeholder', // Bucket should be the namespace in OCI Object Storage

--- a/apps/backoffice/src/schemas/Projects/collection.ts
+++ b/apps/backoffice/src/schemas/Projects/collection.ts
@@ -2,6 +2,8 @@
 
 import { featuredImageField } from '@/fields/featured-image';
 import { isUnlistedField } from '@/fields/is-unlisted';
+import { publishedAtField } from '@/fields/published-at';
+import { updatedAtField } from '@/fields/updated-at';
 import { CollectionConfig } from 'payload';
 
 /* * */
@@ -14,40 +16,56 @@ export const Projects: CollectionConfig = {
 		read: () => true,
 		update: ({ req: { user } }) => Boolean(user),
 	},
+
 	fields: [
 		{
-			admin: {
-				initCollapsed: true,
-			},
+			label: 'Title',
+			name: 'title',
+			type: 'text',
+		},
+		{
+			label: 'Project URL',
+			name: 'more_info_url',
+			type: 'text',
+		},
+		{
+			label: 'Description',
+			name: 'description',
+			type: 'textarea',
+		},
+		{
 			fields: [
 				{
-					fields: [
-						{
-							label: 'Title (used for accessibility)',
-							name: 'title',
-							type: 'text',
-						},
-						{
-							label: 'Project URL',
-							name: 'more_info_url',
-							type: 'text',
-						},
-					],
-					type: 'row',
+					label: 'Keyword',
+					name: 'value',
+					type: 'text',
 				},
-				isUnlistedField,
-				featuredImageField,
 			],
-			name: 'projects',
+			label: 'Keywords',
+			name: 'keywords',
 			type: 'array',
 		},
+		isUnlistedField,
+		publishedAtField,
+		updatedAtField,
+		featuredImageField,
 	],
-
 	labels: {
 		plural: 'Projetos',
 		singular: 'Projeto',
 	},
-
+	/**
+	 * Drag-and-drop order in the admin list view. Adds a hidden `_order` field (fractional index), not an editor-facing form field.
+	 * @see https://payloadcms.com/docs/configuration/collections#orderable
+	 */
+	orderable: true,
 	slug: 'projects',
+	versions: {
+		drafts: {
+			autosave: {
+				interval: 500,
+			},
+		},
+	},
 
 };

--- a/apps/backoffice/src/schemas/Projects/collection.ts
+++ b/apps/backoffice/src/schemas/Projects/collection.ts
@@ -1,0 +1,53 @@
+/* * */
+
+import { featuredImageField } from '@/fields/featured-image';
+import { isUnlistedField } from '@/fields/is-unlisted';
+import { CollectionConfig } from 'payload';
+
+/* * */
+
+export const Projects: CollectionConfig = {
+
+	access: {
+		create: ({ req: { user } }) => Boolean(user),
+		delete: ({ req: { user } }) => Boolean(user),
+		read: () => true,
+		update: ({ req: { user } }) => Boolean(user),
+	},
+	fields: [
+		{
+			admin: {
+				initCollapsed: true,
+			},
+			fields: [
+				{
+					fields: [
+						{
+							label: 'Title (used for accessibility)',
+							name: 'title',
+							type: 'text',
+						},
+						{
+							label: 'Project URL',
+							name: 'more_info_url',
+							type: 'text',
+						},
+					],
+					type: 'row',
+				},
+				isUnlistedField,
+				featuredImageField,
+			],
+			name: 'projects',
+			type: 'array',
+		},
+	],
+
+	labels: {
+		plural: 'Projetos',
+		singular: 'Projeto',
+	},
+
+	slug: 'projects',
+
+};

--- a/apps/backoffice/src/schemas/Projects/collection.ts
+++ b/apps/backoffice/src/schemas/Projects/collection.ts
@@ -20,6 +20,7 @@ export const Projects: CollectionConfig = {
 	fields: [
 		{
 			label: 'Title',
+			localized: true,
 			name: 'title',
 			type: 'text',
 		},
@@ -30,6 +31,7 @@ export const Projects: CollectionConfig = {
 		},
 		{
 			label: 'Description',
+			localized: true,
 			name: 'description',
 			type: 'textarea',
 		},
@@ -54,10 +56,6 @@ export const Projects: CollectionConfig = {
 		plural: 'Projetos',
 		singular: 'Projeto',
 	},
-	/**
-	 * Drag-and-drop order in the admin list view. Adds a hidden `_order` field (fractional index), not an editor-facing form field.
-	 * @see https://payloadcms.com/docs/configuration/collections#orderable
-	 */
 	orderable: true,
 	slug: 'projects',
 	versions: {

--- a/apps/frontend/src/app/(views)/(website)/projects/layout.tsx
+++ b/apps/frontend/src/app/(views)/(website)/projects/layout.tsx
@@ -1,0 +1,13 @@
+/* * */
+
+import { ProjectsListContextProvider } from '@/contexts/ProjectsList.context';
+
+/* * */
+
+export default function Layout({ children }) {
+	return (
+		<ProjectsListContextProvider>
+			{children}
+		</ProjectsListContextProvider>
+	);
+}

--- a/apps/frontend/src/app/(views)/(website)/projects/page.tsx
+++ b/apps/frontend/src/app/(views)/(website)/projects/page.tsx
@@ -1,0 +1,9 @@
+/* * */
+
+import { ProjectsPage } from '@/components/projects/ProjectsPage';
+
+/* * */
+
+export default function Page() {
+	return <ProjectsPage />;
+}

--- a/apps/frontend/src/components/home/FeaturedSection/index.tsx
+++ b/apps/frontend/src/components/home/FeaturedSection/index.tsx
@@ -1,21 +1,22 @@
 /* * */
 
-import FeaturedSectionCard from '@/components/home/FeaturedSectionCard';
-import { Grid } from '@/components/layout/Grid';
 import { Section } from '@/components/layout/Section';
 import { Surface } from '@/components/layout/Surface';
+
+import { ProjectsCarousel } from '../ProjectsCarousel';
 
 /* * */
 
 export function FeaturedSection() {
+	//
+
+	//
+	// A. Render Components
+
 	return (
 		<Surface>
-			<Section heading="Destaques" withPadding>
-				<Grid columns="abc" withGap>
-					<FeaturedSectionCard coverImageSrc="/assets/home/drivers.png" href="https://backoffice.carrismetropolitana.pt/motoristas/" title="Recrutamento" />
-					<FeaturedSectionCard coverImageSrc="/assets/home/loures.png" href="https://carrismetropolitana.pt/news/69a96c64f4ea8db5214711a3" title="Estudo de Caso" />
-					<FeaturedSectionCard coverImageSrc="/assets/home/participe.png" href="https://backoffice.carrismetropolitana.pt/participe" title="Participe" />
-				</Grid>
+			<Section heading="Projetos" withPadding>
+				<ProjectsCarousel />
 			</Section>
 		</Surface>
 	);

--- a/apps/frontend/src/components/home/FeaturedSection/index.tsx
+++ b/apps/frontend/src/components/home/FeaturedSection/index.tsx
@@ -15,7 +15,7 @@ export function FeaturedSection() {
 
 	return (
 		<Surface>
-			<Section heading="Projetos" withPadding>
+			<Section heading="Projetos" href="/projects" withPadding>
 				<ProjectsCarousel />
 			</Section>
 		</Surface>

--- a/apps/frontend/src/components/home/HomePage/index.tsx
+++ b/apps/frontend/src/components/home/HomePage/index.tsx
@@ -3,10 +3,10 @@
 /* * */
 
 import { AlertsSection } from '@/components/home/AlertsSection';
-import { FeaturedSection } from '@/components/home/FeaturedSection';
 import { MainCarousel } from '@/components/home/MainCarousel';
 import { MetricsSection } from '@/components/home/MetricsSection';
 import { NewsSection } from '@/components/home/NewsSection';
+import { ProjectsSection } from '@/components/home/ProjectsSection';
 import { QuickSearch } from '@/components/home/QuickSearch';
 import { SchedulesSection } from '@/components/home/SchedulesSection';
 import { SupportSection } from '@/components/home/SupportSection';
@@ -38,7 +38,7 @@ export function HomePage() {
 			<TarifsSection />
 			<SupportSection />
 			<MetricsSection />
-			<FeaturedSection />
+			<ProjectsSection />
 		</MetricsContextProvider>
 	);
 }

--- a/apps/frontend/src/components/home/ProjectsCarousel/index.tsx
+++ b/apps/frontend/src/components/home/ProjectsCarousel/index.tsx
@@ -25,33 +25,30 @@ export function ProjectsCarousel() {
 	// C. Render components
 
 	return (
-		<>
-			<Carousel
-				classNames={{ control: styles.control, controls: styles.controlsWrapper, root: styles.root, slide: styles.carouselSlide }}
-				emblaOptions={{ align: 'start', slidesToScroll: 1 }}
-				nextControlIcon={<IconArrowRight size={18} />}
-				previousControlIcon={<IconArrowLeft size={18} />}
-				slideGap="md"
-				slideSize={{ base: '100%', md: '33.333333%' }}
-				style={{ flex: 1, maxWidth: '100%' }}
-				withControls={projectsData?.length > 0}
-				withIndicators
-			>
+		<Carousel
+			classNames={{ control: styles.control, controls: styles.controlsWrapper, root: styles.root, slide: styles.carouselSlide }}
+			emblaOptions={{ align: 'start', slidesToScroll: 1 }}
+			nextControlIcon={<IconArrowRight size={18} />}
+			previousControlIcon={<IconArrowLeft size={18} />}
+			slideGap="md"
+			slideSize={{ base: '100%', md: '33.333333%' }}
+			style={{ flex: 1, maxWidth: '100%' }}
+			withControls={projectsData?.length > 0}
+			withIndicators
+		>
 
-				{projectsData?.map(item => (
-					<Carousel.Slide key={item.id ?? item._id} className={styles.slideWrapper}>
-						<ProjectsCarouselCard
-							coverImageSrc={item.featured_image?.thumbnailURL ?? item.featured_image?.url}
-							href={item.more_info_url}
-							keywords={item.keywords}
-							title={item.title}
-						/>
-					</Carousel.Slide>
-				))}
+			{projectsData?.map(item => (
+				<Carousel.Slide key={item.id ?? item._id} className={styles.slideWrapper}>
+					<ProjectsCarouselCard
+						coverImageSrc={item.featured_image?.thumbnailURL ?? item.featured_image?.url}
+						href={item.more_info_url}
+						keywords={item.keywords}
+						title={item.title}
+					/>
+				</Carousel.Slide>
+			))}
 
-			</Carousel>
-
-		</>
+		</Carousel>
 	);
 
 	//

--- a/apps/frontend/src/components/home/ProjectsCarousel/index.tsx
+++ b/apps/frontend/src/components/home/ProjectsCarousel/index.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+/* * */
+
+import { ProjectsCarouselCard } from '@/components/home/ProjectsCarouselCard';
+import { Project } from '@/types/projects.type';
+import { getPublicVariable } from '@carrismetropolitana/website-shared-settings';
+import { Carousel } from '@mantine/carousel';
+import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
+import useSWR from 'swr';
+
+import styles from './styles.module.css';
+
+/* * */
+
+export function ProjectsCarousel() {
+	//
+
+	//
+	// A. Fetch data
+
+	const { data: projectsData } = useSWR<Project[]>(`${getPublicVariable('server_url_backoffice')}/admin/public-api/projects`);
+
+	//
+	// C. Render components
+
+	return (
+		<>
+			<Carousel
+				classNames={{ control: styles.control, controls: styles.controlsWrapper, root: styles.root, slide: styles.carouselSlide }}
+				emblaOptions={{ align: 'start', slidesToScroll: 1 }}
+				nextControlIcon={<IconArrowRight size={18} />}
+				previousControlIcon={<IconArrowLeft size={18} />}
+				slideGap="md"
+				slideSize={{ base: '100%', md: '33.333333%' }}
+				style={{ flex: 1, maxWidth: '100%' }}
+				withControls={projectsData?.length > 0}
+				withIndicators
+			>
+
+				{projectsData?.map(item => (
+					<Carousel.Slide key={item.id ?? item._id} className={styles.slideWrapper}>
+						<ProjectsCarouselCard
+							coverImageSrc={item.featured_image?.thumbnailURL ?? item.featured_image?.url}
+							href={item.more_info_url}
+							keywords={item.keywords}
+							title={item.title}
+						/>
+					</Carousel.Slide>
+				))}
+
+			</Carousel>
+
+		</>
+	);
+
+	//
+}

--- a/apps/frontend/src/components/home/ProjectsCarousel/styles.module.css
+++ b/apps/frontend/src/components/home/ProjectsCarousel/styles.module.css
@@ -4,21 +4,12 @@
 .root {
 	max-width: min(100%, 920px);
 	height: 100%;
-	margin-top: var(--size-spacing-20);
 	cursor: grab;
 	transition: all 200ms ease;
 }
 
 .carouselSlide {
-	box-sizing: border-box;
 	height: 100%;
-	padding: 0 var(--size-spacing-10) var(--size-spacing-10);
-}
-
-.carouselSlide:hover {
-	z-index: 90;
-	box-shadow: 0 0 12px 0 rgb(0 0 0 / 8%);
-	transform: scale(1.01);
 }
 
 .root:active {

--- a/apps/frontend/src/components/home/ProjectsCarousel/styles.module.css
+++ b/apps/frontend/src/components/home/ProjectsCarousel/styles.module.css
@@ -1,0 +1,75 @@
+/* * */
+/* ROOT */
+
+.root {
+	max-width: min(100%, 920px);
+	height: 100%;
+	margin-top: var(--size-spacing-20);
+	cursor: grab;
+	transition: all 200ms ease;
+}
+
+.carouselSlide {
+	box-sizing: border-box;
+	height: 100%;
+	padding: 0 var(--size-spacing-10) var(--size-spacing-10);
+}
+
+.carouselSlide:hover {
+	z-index: 90;
+	box-shadow: 0 0 12px 0 rgb(0 0 0 / 8%);
+	transform: scale(1.01);
+}
+
+.root:active {
+	cursor: grabbing;
+}
+
+
+/* * */
+/* CONTROL */
+
+.control {
+	width: 40px;
+	aspect-ratio: 1;
+	color: var(--color-system-text-300);
+	background-color: var(--color-system-background-100);
+	border: 1px solid var(--color-system-border-200);
+	box-shadow: 0 0 15px 0 rgb(0 0 0 / 10%);
+	opacity: 0.25;
+	transition: all 200ms ease;
+}
+
+.control:hover {
+	color: var(--color-system-text-200);
+	border-color: var(--color-system-text-200);
+	opacity: 1;
+}
+
+.control:active {
+	color: var(--color-system-text-300);
+	background-color: var(--color-system-background-300);
+	border-color: var(--color-system-text-300);
+	opacity: 1;
+}
+
+.control[data-inactive],
+.root:hover .control[data-inactive] {
+	visibility: hidden;
+	opacity: 0;
+}
+
+.root:hover .control {
+	opacity: 1;
+}
+
+/* * */
+/* CONTROLS WRAPPER */
+
+.controlsWrapper {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	padding: 0 var(--size-spacing-30);
+}

--- a/apps/frontend/src/components/home/ProjectsCarouselCard/index.tsx
+++ b/apps/frontend/src/components/home/ProjectsCarouselCard/index.tsx
@@ -1,0 +1,80 @@
+/* * */
+
+import { Image } from '@mantine/core';
+import { IconArrowRight, IconChevronRight } from '@tabler/icons-react';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+
+import styles from './styles.module.css';
+
+/* * */
+
+interface Props {
+	coverImageSrc?: string
+	href?: string
+	keywords?: { id?: string, value?: string }[]
+	title?: string
+}
+
+/* * */
+
+export function ProjectsCarouselCard({ coverImageSrc, href, keywords, title }: Props) {
+	//
+
+	//
+	// A. Setup variables
+
+	const t = useTranslations('home.MainCarouselCard');
+
+	const keywordItems = keywords?.filter(k => k.value?.trim()) ?? [];
+
+	//
+	// B. Render components
+
+	return (
+		<div className={styles.card}>
+			<div className={styles.header}>
+
+				{title && <p className={styles.title}>{title}</p>}
+
+				{href && (
+					<Link aria-label={t('learn_more')} className={styles.headerArrow} href={href} target="_blank">
+						<IconChevronRight size={22} stroke={1.5} />
+					</Link>
+				)}
+
+			</div>
+
+			<div className={styles.imageArea}>
+				<Image
+					alt={title ?? ''}
+					className={styles.image}
+					fallbackSrc="/assets/common/placeholder.png"
+					fit="contain"
+					radius="var(--border-radius-lg)"
+					src={coverImageSrc}
+				/>
+				{href ? (
+					<Link className={styles.learnMore} href={href} target="_blank">
+						{t('learn_more')}
+						<IconArrowRight size={18} />
+					</Link>
+				) : null}
+			</div>
+
+			<div className={styles.body}>
+				{keywordItems.length > 0 ? (
+					<ul className={styles.keywords}>
+						{keywordItems.map((k, i) => (
+							<li key={`${k.value}-${i}`} className={styles.keyword}>
+								{k.value?.startsWith('#') ? k.value : `#${k.value}`}
+							</li>
+						))}
+					</ul>
+				) : null}
+			</div>
+		</div>
+	);
+
+	//
+}

--- a/apps/frontend/src/components/home/ProjectsCarouselCard/index.tsx
+++ b/apps/frontend/src/components/home/ProjectsCarouselCard/index.tsx
@@ -24,7 +24,7 @@ export function ProjectsCarouselCard({ coverImageSrc, href, keywords, title }: P
 	//
 	// A. Setup variables
 
-	const t = useTranslations('home.MainCarouselCard');
+	const t = useTranslations('home.ProjectsCarouselCard');
 
 	const keywordItems = keywords?.filter(k => k.value?.trim()) ?? [];
 
@@ -46,6 +46,7 @@ export function ProjectsCarouselCard({ coverImageSrc, href, keywords, title }: P
 			</div>
 
 			<div className={styles.imageArea}>
+
 				<Image
 					alt={title ?? ''}
 					className={styles.image}
@@ -54,25 +55,24 @@ export function ProjectsCarouselCard({ coverImageSrc, href, keywords, title }: P
 					radius="var(--border-radius-lg)"
 					src={coverImageSrc}
 				/>
-				{href ? (
+
+				{href && (
 					<Link className={styles.learnMore} href={href} target="_blank">
 						{t('learn_more')}
 						<IconArrowRight size={18} />
 					</Link>
-				) : null}
+				)}
 			</div>
 
-			<div className={styles.body}>
-				{keywordItems.length > 0 ? (
-					<ul className={styles.keywords}>
-						{keywordItems.map((k, i) => (
-							<li key={`${k.value}-${i}`} className={styles.keyword}>
-								{k.value?.startsWith('#') ? k.value : `#${k.value}`}
-							</li>
-						))}
-					</ul>
-				) : null}
-			</div>
+			{keywordItems.length > 0 && (
+				<ul className={styles.keywords}>
+					{keywordItems.map((k, i) => (
+						<li key={`${k.value}-${i}`} className={styles.keyword}>
+							{k.value?.startsWith('#') ? k.value : `#${k.value}`}
+						</li>
+					))}
+				</ul>
+			)}
 		</div>
 	);
 

--- a/apps/frontend/src/components/home/ProjectsCarouselCard/styles.module.css
+++ b/apps/frontend/src/components/home/ProjectsCarouselCard/styles.module.css
@@ -1,4 +1,5 @@
 
+
 .card {
 	box-sizing: border-box;
 	display: grid;

--- a/apps/frontend/src/components/home/ProjectsCarouselCard/styles.module.css
+++ b/apps/frontend/src/components/home/ProjectsCarouselCard/styles.module.css
@@ -1,10 +1,13 @@
-/* Card_Project-style: white shell, title + chevron, dominant image, yellow tags */
 
 .card {
+	box-sizing: border-box;
 	display: grid;
 	grid-template-rows: auto minmax(220px, 1fr) auto;
 	grid-template-columns: 1fr;
 	gap: var(--size-spacing-5);
+	min-width: 0;
+	height: 100%;
+	min-height: 0;
 	padding: var(--size-spacing-15);
 	background-color: var(--color-primary-white);
 	border: 1px solid var(--color-system-border-100);
@@ -15,7 +18,10 @@
 .header {
 	display: flex;
 	flex-direction: row;
+	gap: var(--size-spacing-10);
+	align-items: center;
 	justify-content: space-between;
+	min-width: 0;
 }
 
 .title {
@@ -41,6 +47,11 @@
 	width: 100%;
 	height: 100%;
 	object-fit: contain;
+}
+
+.image:hover {
+	opacity: 0.5;
+	transform: scale(1.01);;
 }
 
 .learnMore {
@@ -80,14 +91,14 @@
 .keywords {
 	display: flex;
 	flex-wrap: wrap;
-	gap: var(--size-spacing-8);
+	gap: var(--size-spacing-5);
 	padding: 0;
 	margin: 0;
 	list-style: none;
 }
 
 .keyword {
-	padding: 8px var(--size-spacing-15);
+	padding: 8px var(--size-spacing-10);
 	font-size: 14px;
 	font-weight: 700;
 	line-height: 1.2;

--- a/apps/frontend/src/components/home/ProjectsCarouselCard/styles.module.css
+++ b/apps/frontend/src/components/home/ProjectsCarouselCard/styles.module.css
@@ -1,0 +1,97 @@
+/* Card_Project-style: white shell, title + chevron, dominant image, yellow tags */
+
+.card {
+	display: grid;
+	grid-template-rows: auto minmax(220px, 1fr) auto;
+	grid-template-columns: 1fr;
+	gap: var(--size-spacing-5);
+	padding: var(--size-spacing-15);
+	background-color: var(--color-primary-white);
+	border: 1px solid var(--color-system-border-100);
+	border-radius: var(--border-radius-xl);
+	box-shadow: 0 2px 14px rgb(0 0 0 / 7%);
+}
+
+.header {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.title {
+	margin: 0;
+	font-size: var(--font-size-title);
+	font-weight: var(--font-weight-title);
+	color: var(--color-system-text-100);
+}
+
+.headerArrow {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--color-system-text-300);
+}
+
+.headerArrow:hover {
+	color: var(--color-system-text-100);
+}
+
+
+.image {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+}
+
+.learnMore {
+	position: absolute;
+	bottom: 0;
+	left: 50%;
+	z-index: 1;
+	display: flex;
+	flex-direction: row;
+	gap: var(--size-spacing-5);
+	align-items: center;
+	justify-content: center;
+	padding: var(--size-spacing-5) var(--size-spacing-15);
+	margin: 0 auto;
+	margin-bottom: -20px;
+	font-size: 16px;
+	color: var(--color-primary-black);
+	text-decoration: none;
+	background-color: var(--color-primary-white);
+	border: 1px solid var(--color-primary-black);
+	border-radius: 999px;
+	box-shadow: 0 0 20px 0 rgb(0 0 0 / 20%);
+	opacity: 0;
+	transform: translateX(-50%);
+	transition: all 200ms ease;
+}
+
+.learnMore:hover {
+	background-color: var(--color-brand);
+}
+
+.imageArea:hover .learnMore {
+	margin-bottom: var(--size-spacing-15);
+	opacity: 1;
+}
+
+.keywords {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--size-spacing-8);
+	padding: 0;
+	margin: 0;
+	list-style: none;
+}
+
+.keyword {
+	padding: 8px var(--size-spacing-15);
+	font-size: 14px;
+	font-weight: 700;
+	line-height: 1.2;
+	color: var(--color-primary-black);
+	background-color: var(--color-brand);
+	border-radius: 999px;
+}

--- a/apps/frontend/src/components/home/ProjectsSection/index.tsx
+++ b/apps/frontend/src/components/home/ProjectsSection/index.tsx
@@ -1,13 +1,12 @@
 /* * */
 
+import { ProjectsCarousel } from '@/components/home/ProjectsCarousel';
 import { Section } from '@/components/layout/Section';
 import { Surface } from '@/components/layout/Surface';
 
-import { ProjectsCarousel } from '../ProjectsCarousel';
-
 /* * */
 
-export function FeaturedSection() {
+export function ProjectsSection() {
 	//
 
 	//

--- a/apps/frontend/src/components/projects/ProjectsCard/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsCard/index.tsx
@@ -24,25 +24,21 @@ export function ProjectsCard({ project }: ProjectsCardProps) {
 
 	return (
 		<div className={styles.card}>
+
 			<Image
-				alt={project.title ?? ''}
+				alt={project.title}
 				className={styles.image}
 				fallbackSrc="/assets/common/placeholder.png"
 				radius="var(--border-radius-lg)"
-				src={project.featured_image?.thumbnailURL || project.featured_image?.url}
+				src={project.featured_image?.url}
 			/>
 
 			<div className={styles.content}>
 				<p className={styles.title}>{project.title}</p>
-				{project.description && <p className={styles.description}>{project.description}</p>}
-
-				{project.more_info_url && (
-					<Link className={styles.learnMore} href={project.more_info_url} target="_blank">
-						Learn more
-						<IconArrowRight size={16} />
-					</Link>
-				)}
+				<p className={styles.description}>{project.description}</p>
+				<Link className={styles.learnMore} href={project.more_info_url} target="_blank">Learn more<IconArrowRight size={16} /></Link>
 			</div>
+
 		</div>
 	);
 

--- a/apps/frontend/src/components/projects/ProjectsCard/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsCard/index.tsx
@@ -24,19 +24,23 @@ export function ProjectsCard({ project }: ProjectsCardProps) {
 
 	return (
 		<div className={styles.card}>
+			<p className={styles.title}>{project.title}</p>
 
-			<Image
-				alt={project.title}
-				className={styles.image}
-				fallbackSrc="/assets/common/placeholder.png"
-				radius="var(--border-radius-lg)"
-				src={project.featured_image?.url}
-			/>
+			<div className={styles.body}>
+				<div className={styles.media}>
+					<Image
+						alt={project.title}
+						className={styles.image}
+						fallbackSrc="/assets/common/placeholder.png"
+						radius="var(--border-radius-lg)"
+						src={project.featured_image?.url}
+					/>
+					<Link className={styles.learnMore} href={project.more_info_url} target="_blank">Learn more<IconArrowRight size={16} /></Link>
+				</div>
 
-			<div className={styles.content}>
-				<p className={styles.title}>{project.title}</p>
-				<p className={styles.description}>{project.description}</p>
-				<Link className={styles.learnMore} href={project.more_info_url} target="_blank">Learn more<IconArrowRight size={16} /></Link>
+				<div className={styles.content}>
+					<p className={styles.description}>{project.description}</p>
+				</div>
 			</div>
 
 		</div>

--- a/apps/frontend/src/components/projects/ProjectsCard/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsCard/index.tsx
@@ -1,0 +1,19 @@
+/* * */
+
+import { Project } from '@/types/projects.type';
+
+/* * */
+
+interface ProjectsCardProps {
+	project: Project
+}
+
+/* * */
+
+export function ProjectsCard({ project }: ProjectsCardProps) {
+	return (
+		<div>
+			<p>{project.title}</p>
+		</div>
+	);
+}

--- a/apps/frontend/src/components/projects/ProjectsCard/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsCard/index.tsx
@@ -1,6 +1,12 @@
 /* * */
 
-import { Project } from '@/types/projects.type';
+import type { Project } from '@/types/projects.type';
+
+import { Image } from '@mantine/core';
+import { IconArrowRight } from '@tabler/icons-react';
+import Link from 'next/link';
+
+import styles from './styles.module.css';
 
 /* * */
 
@@ -11,9 +17,34 @@ interface ProjectsCardProps {
 /* * */
 
 export function ProjectsCard({ project }: ProjectsCardProps) {
+	//
+
+	//
+	// A. Render components
+
 	return (
-		<div>
-			<p>{project.title}</p>
+		<div className={styles.card}>
+			<Image
+				alt={project.title ?? ''}
+				className={styles.image}
+				fallbackSrc="/assets/common/placeholder.png"
+				radius="var(--border-radius-lg)"
+				src={project.featured_image?.thumbnailURL || project.featured_image?.url}
+			/>
+
+			<div className={styles.content}>
+				<p className={styles.title}>{project.title}</p>
+				{project.description && <p className={styles.description}>{project.description}</p>}
+
+				{project.more_info_url && (
+					<Link className={styles.learnMore} href={project.more_info_url} target="_blank">
+						Learn more
+						<IconArrowRight size={16} />
+					</Link>
+				)}
+			</div>
 		</div>
 	);
+
+	//
 }

--- a/apps/frontend/src/components/projects/ProjectsCard/styles.module.css
+++ b/apps/frontend/src/components/projects/ProjectsCard/styles.module.css
@@ -1,0 +1,70 @@
+.card {
+	display: grid;
+	grid-template-columns: minmax(180px, 240px) 1fr;
+	gap: var(--size-spacing-10);
+	align-items: start;
+	padding: var(--size-spacing-10);
+	background: var(--color-primary-white);
+	border: 1px solid var(--color-system-border-100);
+	border-radius: var(--border-radius-lg);
+}
+
+.image {
+	width: 100%;
+	height: 120px;
+	object-fit: cover;
+}
+
+.content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-spacing-5);
+}
+
+.title {
+	margin: 0;
+	font-size: var(--font-size-text);
+	font-weight: 700;
+	color: var(--color-system-text-100);
+}
+
+.description {
+	display: -webkit-box;
+	margin: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	-webkit-line-clamp: 4;
+	font-size: var(--font-size-xs);
+	color: var(--color-system-text-200);
+	-webkit-box-orient: vertical;
+}
+
+.learnMore {
+	display: inline-flex;
+	gap: var(--size-spacing-5);
+	align-items: center;
+	align-self: flex-start;
+	padding: 6px var(--size-spacing-10);
+	margin-top: var(--size-spacing-5);
+	font-size: var(--font-size-xs);
+	font-weight: 600;
+	color: var(--color-primary-black);
+	text-decoration: none;
+	background: var(--color-primary-white);
+	border: 1px solid var(--color-system-border-200);
+	border-radius: 999px;
+}
+
+.learnMore:hover {
+	background: var(--color-brand);
+}
+
+@media (width <= 768px) {
+	.card {
+		grid-template-columns: 1fr;
+	}
+
+	.image {
+		height: 150px;
+	}
+}

--- a/apps/frontend/src/components/projects/ProjectsCard/styles.module.css
+++ b/apps/frontend/src/components/projects/ProjectsCard/styles.module.css
@@ -1,66 +1,73 @@
 .card {
-	display: grid;
-	grid-template-columns: minmax(180px, 240px) 1fr;
+	display: flex;
+	flex-direction: column;
 	gap: var(--size-spacing-10);
-	align-items: start;
-	padding: var(--size-spacing-10);
+	padding: var(--size-spacing-15);
 	background: var(--color-primary-white);
 	border: 1px solid var(--color-system-border-100);
-	border-radius: var(--border-radius-lg);
+	border-radius: var(--border-radius-lg)
+}
+
+.body {
+	display: grid;
+	grid-template-columns: minmax(180px, 240px) 1fr;
+	gap: var(--size-spacing-20);
+	align-items: start;
+}
+
+.media {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-spacing-20);
+	align-items: flex-start;
 }
 
 .image {
 	width: 100%;
-	height: 120px;
-	object-fit: cover;
+	height: 100%;
+	object-fit: contain;
 }
 
 .content {
 	display: flex;
 	flex-direction: column;
-	gap: var(--size-spacing-5);
+	gap: var(--size-spacing-10);
 }
 
 .title {
 	margin: 0;
-	font-size: var(--font-size-text);
-	font-weight: 700;
-	color: var(--color-system-text-100);
+	margin-bottom: var(--size-spacing-5);
+	font-size: var(--font-size-title);
+	font-weight: var(--font-weight-title);
+	color: var(--color-system-text-200);
 }
 
 .description {
-	display: -webkit-box;
 	margin: 0;
 	overflow: hidden;
-	text-overflow: ellipsis;
-	-webkit-line-clamp: 4;
-	font-size: var(--font-size-xs);
+	font-size: var(--font-size-text);
 	color: var(--color-system-text-200);
-	-webkit-box-orient: vertical;
 }
 
 .learnMore {
 	display: inline-flex;
 	gap: var(--size-spacing-5);
 	align-items: center;
-	align-self: flex-start;
-	padding: 6px var(--size-spacing-10);
-	margin-top: var(--size-spacing-5);
-	font-size: var(--font-size-xs);
-	font-weight: 600;
-	color: var(--color-primary-black);
+	justify-content: space-evenly;
+	width: 150px;
+	padding: var(--size-spacing-5);
+	margin-bottom: var(--size-spacing-5);
+	font-size: var(--font-size-text);
+	font-weight: var(--font-weight-title);
+	color: var(--color-system-text-200);
 	text-decoration: none;
-	background: var(--color-primary-white);
+	background: var(--color-system-background-100);
 	border: 1px solid var(--color-system-border-200);
-	border-radius: 999px;
-}
-
-.learnMore:hover {
-	background: var(--color-brand);
+	border-radius: var(--border-radius-lg);
 }
 
 @media (width <= 768px) {
-	.card {
+	.body {
 		grid-template-columns: 1fr;
 	}
 

--- a/apps/frontend/src/components/projects/ProjectsList/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsList/index.tsx
@@ -18,11 +18,7 @@ export function ProjectsList() {
 	// B. Render Components
 
 	return (
-		<Grid
-			children={projectsContext.data.raw.map(item => (<ProjectsCard key={`${item._id}-${item.title}`} project={item} />))}
-			columns="ab"
-			withGap
-		/>
+		<Grid children={projectsContext.data.raw.map(item => (<ProjectsCard key={`${item._id}-${item.title}`} project={item} />))} columns="ab" withGap />
 	);
 
 	//

--- a/apps/frontend/src/components/projects/ProjectsList/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsList/index.tsx
@@ -19,10 +19,8 @@ export function ProjectsList() {
 
 	return (
 		<Grid
+			children={projectsContext.data.raw.map(item => (<ProjectsCard key={`${item._id}-${item.title}`} project={item} />))}
 			columns="ab"
-			children={projectsContext.data.raw.map(item => (
-				<ProjectsCard key={`${item._id}-${item.title}`} project={item} />
-			))}
 			withGap
 		/>
 	);

--- a/apps/frontend/src/components/projects/ProjectsList/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsList/index.tsx
@@ -1,0 +1,28 @@
+/* * */
+
+import { useProjectsListContext } from '@/contexts/ProjectsList.context';
+
+/* * */
+
+export function ProjectsList() {
+	//
+
+	//
+	// A. Setup Variables
+
+	const projectsContext = useProjectsListContext();
+
+	//
+	// B. Render Components
+
+	return (
+		projectsContext.data.raw.map(item => (
+			<>
+				{item.title}
+			</>
+		),
+		)
+	);
+
+	//
+}

--- a/apps/frontend/src/components/projects/ProjectsList/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsList/index.tsx
@@ -1,10 +1,8 @@
 /* * */
 
 import { Grid } from '@/components/layout/Grid';
-import { Surface } from '@/components/layout/Surface';
+import { ProjectsCard } from '@/components/projects/ProjectsCard';
 import { useProjectsListContext } from '@/contexts/ProjectsList.context';
-
-import { ProjectsCard } from '../ProjectsCard';
 
 /* * */
 
@@ -20,15 +18,13 @@ export function ProjectsList() {
 	// B. Render Components
 
 	return (
-		<Surface>
-			<Grid
-				columns="ab"
-				children={projectsContext.data.raw.map(item => (
-					<ProjectsCard key={`${item._id}-${item.title}`} project={item} />
-				))}
-				withGap
-			/>
-		</Surface>
+		<Grid
+			columns="ab"
+			children={projectsContext.data.raw.map(item => (
+				<ProjectsCard key={`${item._id}-${item.title}`} project={item} />
+			))}
+			withGap
+		/>
 	);
 
 	//

--- a/apps/frontend/src/components/projects/ProjectsList/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsList/index.tsx
@@ -1,6 +1,10 @@
 /* * */
 
+import { Grid } from '@/components/layout/Grid';
+import { Surface } from '@/components/layout/Surface';
 import { useProjectsListContext } from '@/contexts/ProjectsList.context';
+
+import { ProjectsCard } from '../ProjectsCard';
 
 /* * */
 
@@ -16,12 +20,15 @@ export function ProjectsList() {
 	// B. Render Components
 
 	return (
-		projectsContext.data.raw.map(item => (
-			<>
-				{item.title}
-			</>
-		),
-		)
+		<Surface>
+			<Grid
+				columns="ab"
+				children={projectsContext.data.raw.map(item => (
+					<ProjectsCard key={`${item._id}-${item.title}`} project={item} />
+				))}
+				withGap
+			/>
+		</Surface>
 	);
 
 	//

--- a/apps/frontend/src/components/projects/ProjectsPage/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsPage/index.tsx
@@ -26,11 +26,11 @@ export function ProjectsPage() {
 			<Surface>
 				<Section heading={t('heading')} subheading={t('subheading')} />
 			</Surface>
-			<Surface>
-				<Section withPadding>
-					<ProjectsList />
-				</Section>
-			</Surface>
+
+			<Section>
+				<ProjectsList />
+			</Section>
+
 		</>
 	);
 

--- a/apps/frontend/src/components/projects/ProjectsPage/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsPage/index.tsx
@@ -26,7 +26,11 @@ export function ProjectsPage() {
 			<Surface>
 				<Section heading={t('heading')} subheading={t('subheading')} />
 			</Surface>
-			<ProjectsList />
+			<Surface>
+				<Section withPadding>
+					<ProjectsList />
+				</Section>
+			</Surface>
 		</>
 	);
 

--- a/apps/frontend/src/components/projects/ProjectsPage/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsPage/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Grid } from '@/components/layout/Grid';
 /* * */
 
 import { Section } from '@/components/layout/Section';

--- a/apps/frontend/src/components/projects/ProjectsPage/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsPage/index.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Grid } from '@/components/layout/Grid';
+/* * */
+
+import { Section } from '@/components/layout/Section';
+import { Surface } from '@/components/layout/Surface';
+import { ProjectsList } from '@/components/projects/ProjectsList';
+import { useTranslations } from 'next-intl';
+
+/* * */
+
+export function ProjectsPage() {
+	//
+
+	//
+	// A. Setup variables
+
+	const t = useTranslations('projects.ProjectsPage');
+
+	//
+	// B. Render components
+
+	return (
+		<Surface>
+			<Section heading={t('heading')} subheading={t('subheading')} withGap withPadding />
+			<Grid children={<ProjectsList />} columns="ab" withGap />
+		</Surface>
+	);
+
+	//
+}

--- a/apps/frontend/src/components/projects/ProjectsPage/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsPage/index.tsx
@@ -22,10 +22,12 @@ export function ProjectsPage() {
 	// B. Render components
 
 	return (
-		<Surface>
-			<Section heading={t('heading')} subheading={t('subheading')} withGap withPadding />
-			<Grid children={<ProjectsList />} columns="ab" withGap />
-		</Surface>
+		<>
+			<Surface>
+				<Section heading={t('heading')} subheading={t('subheading')} />
+			</Surface>
+			<ProjectsList />
+		</>
 	);
 
 	//

--- a/apps/frontend/src/components/projects/ProjectsPage/index.tsx
+++ b/apps/frontend/src/components/projects/ProjectsPage/index.tsx
@@ -25,11 +25,9 @@ export function ProjectsPage() {
 			<Surface>
 				<Section heading={t('heading')} subheading={t('subheading')} />
 			</Surface>
-
 			<Section>
 				<ProjectsList />
 			</Section>
-
 		</>
 	);
 

--- a/apps/frontend/src/contexts/ProjectsList.context.tsx
+++ b/apps/frontend/src/contexts/ProjectsList.context.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+/* * */
+
+import type { Project } from '@/types/projects.type';
+
+import { getPublicVariable } from '@carrismetropolitana/website-shared-settings';
+import { createContext, useContext } from 'react';
+import useSWR from 'swr';
+
+/* * */
+
+interface ProjectsListContextState {
+	data: {
+		raw: Project[]
+	}
+	flags: {
+		is_loading: boolean
+	}
+}
+
+/* * */
+
+const ProjectsListContext = createContext<null | ProjectsListContextState>(null);
+
+export function useProjectsListContext() {
+	const context = useContext(ProjectsListContext);
+	if (!context) {
+		throw new Error('useCampaignsListContext must be used within a CampaignsListContextProvider');
+	}
+	return context;
+}
+
+/* * */
+
+export const ProjectsListContextProvider = ({ children }) => {
+	//
+
+	//
+	// B. Fetch data
+
+	const projectsApiUrl = `${getPublicVariable('server_url_backoffice')}/admin/public-api/projects`;
+	const { data: allProjectsData, isLoading: allProjectsLoading } = useSWR<Project[], Error>(projectsApiUrl, { refreshInterval: 900000 }); // 15 minutes
+
+	//
+	// E. Define context value
+
+	const contextValue: ProjectsListContextState = {
+		data: {
+			raw: allProjectsData || [],
+		},
+		flags: {
+			is_loading: allProjectsLoading,
+		},
+	};
+
+	//
+	// F. Render components
+
+	return (
+		<ProjectsListContext.Provider value={contextValue}>
+			{children}
+		</ProjectsListContext.Provider>
+	);
+
+	//
+};

--- a/apps/frontend/src/contexts/ProjectsList.context.tsx
+++ b/apps/frontend/src/contexts/ProjectsList.context.tsx
@@ -4,6 +4,8 @@
 
 import type { Project } from '@/types/projects.type';
 
+import { useLocaleContext } from '@/contexts/Locale.context';
+import { DEFAULT_LOCALE_CODE, getMatchingLocale } from '@/i18n/config';
 import { getPublicVariable } from '@carrismetropolitana/website-shared-settings';
 import { createContext, useContext } from 'react';
 import useSWR from 'swr';
@@ -36,10 +38,16 @@ export function useProjectsListContext() {
 export const ProjectsListContextProvider = ({ children }) => {
 	//
 
+	const localeContext = useLocaleContext();
+	const currentLocale = localeContext.data.current_locale;
+
 	//
 	// B. Fetch data
 
-	const projectsApiUrl = `${getPublicVariable('server_url_backoffice')}/admin/public-api/projects`;
+	const matchingLocale = getMatchingLocale(currentLocale) ?? getMatchingLocale(DEFAULT_LOCALE_CODE);
+	const normalizedLocaleCode = matchingLocale?._id ?? DEFAULT_LOCALE_CODE;
+	const payloadLocale = normalizedLocaleCode === 'en' ? 'en' : 'pt-PT';
+	const projectsApiUrl = `${getPublicVariable('server_url_backoffice')}/admin/public-api/projects?locale=${payloadLocale}`;
 	const { data: allProjectsData, isLoading: allProjectsLoading } = useSWR<Project[], Error>(projectsApiUrl, { refreshInterval: 900000 }); // 15 minutes
 
 	//

--- a/apps/frontend/src/i18n/translations/en.json
+++ b/apps/frontend/src/i18n/translations/en.json
@@ -1693,6 +1693,12 @@
 			"success": "Profile synchronized successfully!"
 		}
 	},
+	"projects": {
+		"ProjectsPage": {
+			"heading": "Projects",
+			"subheading": "Carris Metropolitana develops projects in various areas, aiming to contribute to more sustainable mobility, foster a closer relationship with passengers, or showcase different aspects of road transport operations. Learn more about them below:"
+		}
+	},
 	"review-2024": {
 		"Review2024Card": {
 			"share": {
@@ -1974,6 +1980,7 @@
 					"metrics": "Our live operation",
 					"news": "News",
 					"open-data": "Open Data",
+					"projects": "Projects",
 					"vehicles": "Fleet"
 				}
 			},

--- a/apps/frontend/src/i18n/translations/en.json
+++ b/apps/frontend/src/i18n/translations/en.json
@@ -59,7 +59,7 @@
 		}
 	},
 	"NewsCard": {
-		"publish_date": "{publishDate, date, long}",
+		"publish_date": "{published_at, date, long}",
 		"see_more": "See More"
 	},
 	"PipsSurvey": {

--- a/apps/frontend/src/i18n/translations/en.json
+++ b/apps/frontend/src/i18n/translations/en.json
@@ -189,6 +189,7 @@
 				"HIGH_PASSENGER_LOAD": "High Passenger Load",
 				"MEDICAL_EMERGENCY": "Medical Emergency",
 				"NETWORK_UPDATE": "Network Update",
+				"OTHER_CAUSE": "Network Update",
 				"POLICE_ACTIVITY": "Police Activity",
 				"PUBLIC_DISORDER": "Public Disorder",
 				"ROAD_ISSUE": "Road Issue",
@@ -714,6 +715,9 @@
 		},
 		"NewsSection": {
 			"section_heading": "News"
+		},
+		"ProjectsCarouselCard": {
+			"learn_more": "Find out more"
 		},
 		"QuickSearchFavoritesBar": {
 			"empty": "No favorite lines yet...",

--- a/apps/frontend/src/i18n/translations/pt.json
+++ b/apps/frontend/src/i18n/translations/pt.json
@@ -1694,6 +1694,12 @@
 			"success": "Perfil sincronizado com sucesso!"
 		}
 	},
+	"projects": {
+		"ProjectsPage": {
+			"heading": "Projetos",
+			"subheading": "A Carris Metropolitana desenvolve projetos de diferentes âmbitos, que procuram contribuir para uma mobilidade mais sustentável, ter uma relação mais próxima com os passageiros, ou demonstrar diferentes aspetos da operação rodoviária. Conheça-os abaixo: "
+		}
+	},
 	"review-2024": {
 		"Review2024Card": {
 			"share": {
@@ -1975,6 +1981,7 @@
 					"metrics": "A nossa Operação ao Vivo",
 					"news": "Notícias",
 					"open-data": "Dados Abertos",
+					"projects": "Projetos",
 					"vehicles": "Frota"
 				}
 			},

--- a/apps/frontend/src/i18n/translations/pt.json
+++ b/apps/frontend/src/i18n/translations/pt.json
@@ -717,6 +717,9 @@
 		"NewsSection": {
 			"section_heading": "Notícias"
 		},
+		"ProjectsCarouselCard": {
+			"learn_more": "Saber mais"
+		},
 		"QuickSearchFavoritesBar": {
 			"empty": "Ainda não tem linhas favoritas...",
 			"more": "{count, plural, one {+ # linha} other {+ # linhas}}"

--- a/apps/frontend/src/settings/navigation.settings.tsx
+++ b/apps/frontend/src/settings/navigation.settings.tsx
@@ -1,7 +1,7 @@
 /* * */
 
 import { type NavigationGroup } from '@/types/navigation.types';
-import { IconAlertTriangle, IconArrowLoopRight, IconBellSchool, IconBuildingStore, IconBus, IconBusStop, IconChartBar, IconCreditCard, IconCreditCardPay, IconDirections, IconHelpHexagon, IconHomeSpark, IconListSearch, IconMapQuestion, IconMessages, IconNews, IconPrompt, IconTicket, IconUserHeart } from '@tabler/icons-react';
+import { IconAlertTriangle, IconArrowLoopRight, IconBellSchool, IconBuildingStore, IconBus, IconBusStop, IconChartBar, IconCreditCard, IconCreditCardPay, IconDirections, IconFileArrowRight, IconHelpHexagon, IconHomeSpark, IconListSearch, IconMapQuestion, IconMessages, IconNews, IconPrompt, IconTicket, IconUserHeart } from '@tabler/icons-react';
 
 /* * */
 
@@ -43,6 +43,7 @@ export const mainNavigationGroup: NavigationGroup[] = [
 		_id: 'more',
 		links: [
 			{ _id: 'news', href: '/news', icon: <IconNews /> },
+			{ _id: 'projects', href: '/projects', icon: <IconFileArrowRight /> },
 			{ _id: 'metrics', href: '/metrics', icon: <IconChartBar /> },
 			{ _id: 'open-data', href: '/open-data', icon: <IconPrompt /> },
 			{ _id: 'drivers', href: '/drivers', icon: <IconUserHeart />, target: '_blank' },

--- a/apps/frontend/src/types/projects.type.ts
+++ b/apps/frontend/src/types/projects.type.ts
@@ -1,0 +1,17 @@
+export interface Project {
+	_id?: string
+	_status?: 'draft' | 'published'
+	description?: string
+	featured_image?: {
+		filename?: string
+		thumbnailURL?: string
+		url?: string
+	}
+	id: string
+	is_unlisted?: boolean
+	keywords?: { id?: string, value?: string }[]
+	more_info_url?: string
+	publishedAt: string
+	title?: string
+	updatedAt: string
+}


### PR DESCRIPTION
- Add projects feature end-to-end (backoffice + frontend).
- Create Payload projects collection (title, description, more_info_url, keywords, image, publish/unlisted controls).
- Add public API endpoints for projects list + detail (/admin/public-api/projects, /admin/public-api/projects/[slug]).
- Add localization support for projects content ( locale/fallback passed through public API).
- Add website Projects page + card/list components + projects context data fetch.
- Replace home featured block with Projects section/carousel and add navigation + i18n strings (pt/en) + Project type definitions.