### PR TITLE
refactor: update Arrabida365 banner corrida

### DIFF
--- a/apps/frontend/src/components/arrabida/Arrabida365/index.tsx
+++ b/apps/frontend/src/components/arrabida/Arrabida365/index.tsx
@@ -44,7 +44,7 @@ export function Arrabida365() {
 							src="/assets/arrabidas/arrabida_365_map.png"
 							width={1920}
 						/>
-						<div className={styles.imageBeeWrapper}>
+						{/* <div className={styles.imageBeeWrapper}>
 							<Link className={styles.learnMore} href="/news/31372">
 								{t('buttonSeeMore')}
 								<IconArrowRight size={18} />
@@ -54,6 +54,20 @@ export function Arrabida365() {
 								className={styles.imageBee}
 								height={1080}
 								src="https://backoffice.carrismetropolitana.pt/wp-content/uploads/2025/10/arrabida-banner.jpeg"
+								width={1920}
+							/>
+						</div>*/}
+						<div className={styles.imageBeeWrapper}>
+							<Link className={styles.learnMore} href="https://www.mun-setubal.pt/wp-content/uploads/2026/04/FCS26-PROGRAMA-PTonline.pdf" 
+							target="_blank" rel="noopener noreferrer">
+								{t('buttonSeeMore')}
+								<IconArrowRight size={18} />
+							</Link>
+							<img
+								alt={t('altImageBee')}
+								className={styles.imageBee}
+								height={1080}
+								src="https://staging.carrismetropolitana.pt/admin/api/media/file/media-1777386013015-sta_de_caminhadas_arrabida.jpg"
 								width={1920}
 							/>
 						</div>


### PR DESCRIPTION
Esta PR atualiza o banner da página Arrábida365.

Alterações realizadas:
- Atualização da ligação associada ao banner.
- A ligação passa a abrir numa nova aba.
- Remoção do bloco anterior que estava comentado no componente.
- Não foram feitas alterações fora do componente Arrábida365.