### PR TITLE
feat(frontend): display GO API ETAs alongside production arrivals in debug mode

### DIFF
--- a/apps/frontend/src/components/common/NextArrivals/index.tsx
+++ b/apps/frontend/src/components/common/NextArrivals/index.tsx
@@ -5,7 +5,6 @@
 import type { ArrivalStatus } from '@/types/stops.types';
 
 import { LiveIcon } from '@/components/common/LiveIcon';
-import { useDebugContext } from '@/contexts/Debug.context';
 import { IconAlertCircleFilled, IconClockHour9 } from '@tabler/icons-react';
 import { DateTime } from 'luxon';
 import { useTranslations } from 'next-intl';
@@ -39,10 +38,8 @@ export function NextArrivals({ allowPastArrivals = true, arrivals, status, withI
 	// A. Setup variables
 
 	const t = useTranslations('common.NextArrivals');
-	const debugContext = useDebugContext();
 
 	const [allFormattedArrivals, setFormattedArrivals] = useState<NextArrival[]>([]);
-	const isDebugMode = debugContext.flags.is_debug_mode;
 
 	//
 	// B. Transform data
@@ -124,10 +121,10 @@ export function NextArrivals({ allowPastArrivals = true, arrivals, status, withI
 
 	if (status === 'realtime') {
 		return (
-			<div className={`${styles.container} ${styles.realtime} ${isDebugMode && styles.debug}`}>
+			<div className={`${styles.container} ${styles.realtime}`}>
 				{withIcon && (
 					<div className={styles.icon}>
-						<LiveIcon color={isDebugMode ? 'var(--color-debug)' : undefined} />
+						<LiveIcon />
 					</div>
 				)}
 				<div className={styles.list}>

--- a/apps/frontend/src/components/common/NextArrivals/index.tsx
+++ b/apps/frontend/src/components/common/NextArrivals/index.tsx
@@ -5,6 +5,8 @@
 import type { ArrivalStatus } from '@/types/stops.types';
 
 import { LiveIcon } from '@/components/common/LiveIcon';
+import { useDebugContext } from '@/contexts/Debug.context';
+import { useStopsDetailContext } from '@/contexts/StopsDetail.context';
 import { IconAlertCircleFilled, IconClockHour9 } from '@tabler/icons-react';
 import { DateTime } from 'luxon';
 import { useTranslations } from 'next-intl';
@@ -26,12 +28,41 @@ interface Props {
 	allowPastArrivals?: boolean
 	arrivals: number[]
 	status: ArrivalStatus
+	tripId?: string
 	withIcon?: boolean
 }
 
 /* * */
 
-export function NextArrivals({ allowPastArrivals = true, arrivals, status, withIcon = true }: Props) {
+// Debug-only sub-component: shows the matching GO API ETA alongside the
+// production realtime arrival. Renders nothing when debug mode is off or
+// when no matching GO arrival exists for the given trip.
+function DebugGoArrival({ tripId }: { tripId?: string }) {
+	const debugContext = useDebugContext();
+	const stopsDetailContext = useStopsDetailContext();
+
+	if (!debugContext.flags.is_debug_mode || !tripId) return null;
+
+	const goArrival = stopsDetailContext.data.timetable_realtime_go?.find(arrival => arrival.trip_id === tripId);
+	const goUnix = goArrival?.estimated_arrival_unix ?? goArrival?.scheduled_arrival_unix;
+	if (!goUnix) return null;
+
+	const nowInSeconds = DateTime.now().toSeconds();
+	const minutesUntilArrival = Math.floor((goUnix - nowInSeconds) / 60);
+	const label = minutesUntilArrival <= 0
+		? '<1 min'
+		: `${minutesUntilArrival} min`;
+
+	return (
+		<p className={styles.debugGo} title="GO ETA (debug)">
+			{label}
+		</p>
+	);
+}
+
+/* * */
+
+export function NextArrivals({ allowPastArrivals = true, arrivals, status, tripId, withIcon = true }: Props) {
 	//
 
 	//
@@ -133,6 +164,7 @@ export function NextArrivals({ allowPastArrivals = true, arrivals, status, withI
 							{formattedArrival.label}
 						</p>
 					))}
+					<DebugGoArrival tripId={tripId} />
 				</div>
 			</div>
 		);

--- a/apps/frontend/src/components/common/NextArrivals/styles.module.css
+++ b/apps/frontend/src/components/common/NextArrivals/styles.module.css
@@ -68,3 +68,14 @@
 	color: var(--color-status-danger-text);
 	text-decoration: line-through;
 }
+
+/* * */
+/* DEBUG GO ARRIVAL */
+
+.debugGo {
+	font-size: 16px;
+	font-weight: var(--font-weight-bold);
+	line-height: 1.1;
+	color: var(--color-brand-go);
+	text-wrap: nowrap;
+}

--- a/apps/frontend/src/components/common/NextArrivals/styles.module.css
+++ b/apps/frontend/src/components/common/NextArrivals/styles.module.css
@@ -52,10 +52,6 @@
 	color: var(--color-realtime-100);
 }
 
-.realtime.debug .arrival {
-	color: var(--color-go);
-}
-
 .scheduled .arrival {
 	font-weight: var(--font-weight-bold);
 	font-variant-numeric: tabular-nums;

--- a/apps/frontend/src/components/lines/LinesDetailPathList/index.tsx
+++ b/apps/frontend/src/components/lines/LinesDetailPathList/index.tsx
@@ -5,11 +5,10 @@
 import { NoDataLabel } from '@/components/layout/NoDataLabel';
 import { PathWaypoint } from '@/components/lines/PathWaypoint';
 import { useAnalyticsContext } from '@/contexts/Analytics.context';
-import { useDebugContext } from '@/contexts/Debug.context';
 import { useLinesDetailContext } from '@/contexts/LinesDetail.context';
 import { NextArrival } from '@/types/timetables.types';
-import { getArrivalsApiBaseUrl } from '@/utils/getArrivalsApiBaseUrl';
 import { PatternRealtime } from '@/utils/types';
+import { getPublicVariable } from '@carrismetropolitana/website-shared-settings';
 import { useEffect, useMemo } from 'react';
 import useSWR from 'swr';
 
@@ -25,12 +24,11 @@ export function LinesDetailPathList() {
 
 	const linesDetailContext = useLinesDetailContext();
 	const analyticsContext = useAnalyticsContext();
-	const debugContext = useDebugContext();
 
 	//
 	// B. Fetch data
 
-	const { data: patternRealtimeData } = useSWR<PatternRealtime[]>(linesDetailContext.data.active_pattern?.id && `${getArrivalsApiBaseUrl(debugContext.flags.is_debug_mode)}/arrivals/by_pattern/${linesDetailContext.data.active_pattern.id}`, { refreshInterval: 10000 });
+	const { data: patternRealtimeData } = useSWR<PatternRealtime[]>(linesDetailContext.data.active_pattern?.id && `${getPublicVariable('api_url')}/arrivals/by_pattern/${linesDetailContext.data.active_pattern.id}`, { refreshInterval: 10000 });
 
 	//
 	// C. Transform data

--- a/apps/frontend/src/components/lines/PathWaypointNextArrivals/index.tsx
+++ b/apps/frontend/src/components/lines/PathWaypointNextArrivals/index.tsx
@@ -1,9 +1,6 @@
-'use client';
-
 /* * */
 
 import { LiveIcon } from '@/components/common/LiveIcon';
-import { useDebugContext } from '@/contexts/Debug.context';
 import { IconClockHour9 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useTranslations } from 'next-intl';
@@ -19,10 +16,8 @@ export function PathWaypointNextArrivals({ realtimeArrivals, scheduledArrivals }
 	// A. Setup variables
 
 	const t = useTranslations('lines.PathStopNextArrivals');
-	const debugContext = useDebugContext();
 
 	const now = Date.now();
-	const isDebugMode = debugContext.flags.is_debug_mode;
 
 	//
 	// D. Render components
@@ -37,8 +32,8 @@ export function PathWaypointNextArrivals({ realtimeArrivals, scheduledArrivals }
 			<div className={styles.arrivalsWrapper}>
 
 				{realtimeArrivals.length > 0 && (
-					<div className={`${styles.realtimeArrivalsWrapper} ${isDebugMode && styles.debug}`}>
-						<LiveIcon color={isDebugMode ? 'var(--color-debug)' : undefined} />
+					<div className={styles.realtimeArrivalsWrapper}>
+						<LiveIcon />
 						<div className={styles.realtimeArrivalsList}>
 							{realtimeArrivals.map(realtimeArrival => realtimeArrival != undefined && (
 								<div key={realtimeArrival.unixTs} className={styles.realtimeArrival}>{formatDelta(realtimeArrival.unixTs - now)}</div>

--- a/apps/frontend/src/components/lines/PathWaypointNextArrivals/styles.module.css
+++ b/apps/frontend/src/components/lines/PathWaypointNextArrivals/styles.module.css
@@ -30,18 +30,18 @@
 .scheduledArrivalsWrapper {
 	display: flex;
 	flex-direction: row;
-	gap: var(--size-spacing-5);
 	align-items: center;
 	justify-content: flex-start;
+	gap: var(--size-spacing-5);
 }
 
 .realtimeArrivalsList,
 .scheduledArrivalsList {
 	display: flex;
 	flex-direction: row;
-	gap: var(--size-spacing-10);
 	align-items: center;
 	justify-content: flex-start;
+	gap: var(--size-spacing-10);
 }
 
 /* * */
@@ -51,10 +51,6 @@
 	font-size: 16px;
 	font-weight: var(--font-weight-bold);
 	color: var(--color-realtime-100);
-}
-
-.realtimeArrivalsWrapper.debug .realtimeArrival {
-	color: var(--color-go);
 }
 
 /* * */

--- a/apps/frontend/src/components/stops/StopsDetailContentTimetableRow/index.tsx
+++ b/apps/frontend/src/components/stops/StopsDetailContentTimetableRow/index.tsx
@@ -90,6 +90,7 @@ export function StopsDetailContentTimetableRow({ arrivalData, status }: Props) {
 				<NextArrivals
 					arrivals={[arrivalData.observed_arrival_unix || arrivalData.scheduled_arrival_unix]}
 					status={status}
+					tripId={arrivalData.trip_id}
 					withIcon={true}
 				/>
 			</div>

--- a/apps/frontend/src/contexts/StopsDetail.context.tsx
+++ b/apps/frontend/src/contexts/StopsDetail.context.tsx
@@ -36,6 +36,7 @@ interface StopsDetailContextState {
 		stop: Stop | undefined
 		timetable_realtime: Arrival[] | undefined
 		timetable_realtime_future: Arrival[] | undefined
+		timetable_realtime_go: Arrival[] | undefined
 		timetable_realtime_past: Arrival[] | undefined
 		timetable_schedule: Arrival[] | undefined
 		valid_pattern_groups: Pattern[] | undefined
@@ -83,6 +84,7 @@ export const StopsDetailContextProvider = ({ children, stopId }: { children: Rea
 	const [dataPatternsState, setDataPatternsState] = useState<Pattern[][] | undefined>(undefined);
 	const [dataValidPatternsState, setDataValidPatternsState] = useState<Pattern[] | undefined>(undefined);
 	const [dataShapeState, setDataShapeState] = useState<Shape | undefined>(undefined);
+	const [dataArrivalsGo, setDataArrivalsGo] = useState<Arrival[] | undefined>(undefined);
 	const [dataTimetableRealtimeState, setDataTimetableRealtimeState] = useState<Arrival[] | undefined>(undefined);
 	const [dataTimetableRealtimePastState, setDataTimetableRealtimePastState] = useState<Arrival[] | undefined>(undefined);
 	const [dataTimetableRealtimeFutureState, setDataTimetableRealtimeFutureState] = useState<Arrival[] | undefined>(undefined);
@@ -128,14 +130,10 @@ export const StopsDetailContextProvider = ({ children, stopId }: { children: Rea
 	}, [dataStopState]);
 
 	/**
-
- * Fetch realtime arrivals data for the selected stop.
-
- * This effect runs whenever the `dataStopState` changes.
-
- * It fetches line data for each line associated with the stop and updates the state.
-
- */
+	* Fetch realtime arrivals data for the selected stop.
+	* This effect runs whenever the `dataStopState` changes.
+	* It fetches line data for each line associated with the stop and updates the state.
+	*/
 
 	useEffect(() => {
 		const fetchData = async () => {
@@ -151,6 +149,34 @@ export const StopsDetailContextProvider = ({ children, stopId }: { children: Rea
 			catch (error) {
 				console.error('Error fetching realtime data:', error);
 				setDataTimetableRealtimeState([]);
+			}
+		};
+		//
+		fetchData();
+		const interval = setInterval(fetchData, 10000);
+		return () => clearInterval(interval);
+	}, [dataActiveStopIdState]);
+
+	/**
+	* Fetch realtime arrivals data for the selected stop from GO API.
+	* This effect runs whenever the `dataStopState` changes.
+	* It fetches line data for each line associated with the stop and updates the state.
+	*/
+
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				if (!dataActiveStopIdState) return;
+				const realtimeData = await fetch(`https://go.tmlmobilidade.pt/eta/api/arrivals/by_stop/${dataActiveStopIdState}`)
+					.then((response) => {
+						if (!response.ok) console.log(`Failed to fetch realtime data for stopId: ${dataActiveStopIdState}`);
+						else return response.json();
+					});
+				setDataArrivalsGo(realtimeData);
+			}
+			catch (error) {
+				console.error('Error fetching realtime data:', error);
+				setDataArrivalsGo([]);
 			}
 		};
 		//
@@ -443,6 +469,7 @@ export const StopsDetailContextProvider = ({ children, stopId }: { children: Rea
 			stop: dataStopState,
 			timetable_realtime: dataTimetableRealtimeState,
 			timetable_realtime_future: dataTimetableRealtimeFutureState,
+			timetable_realtime_go: dataArrivalsGo,
 			timetable_realtime_past: dataTimetableRealtimePastState,
 			timetable_schedule: dataTimetableScheduleState,
 			valid_pattern_groups: dataValidPatternsState,

--- a/apps/frontend/src/contexts/StopsDetail.context.tsx
+++ b/apps/frontend/src/contexts/StopsDetail.context.tsx
@@ -10,7 +10,6 @@ import { useProfileContext } from '@/contexts/Profile.context';
 import { useStopsContext } from '@/contexts/Stops.context';
 import { type SimplifiedAlert } from '@/types/alerts.types';
 import { type Arrival } from '@/types/stops.types';
-import { getArrivalsApiBaseUrl } from '@/utils/getArrivalsApiBaseUrl';
 import { type Line, type Pattern, type Shape, type Stop } from '@carrismetropolitana/api-types/network';
 import { getPublicVariable } from '@carrismetropolitana/website-shared-settings';
 import { DateTime } from 'luxon';
@@ -142,7 +141,7 @@ export const StopsDetailContextProvider = ({ children, stopId }: { children: Rea
 		const fetchData = async () => {
 			try {
 				if (!dataActiveStopIdState) return;
-				const realtimeData = await fetch(`${getArrivalsApiBaseUrl(debugContext.flags.is_debug_mode)}/arrivals/by_stop/${dataActiveStopIdState}`)
+				const realtimeData = await fetch(`${getPublicVariable('api_url')}/arrivals/by_stop/${dataActiveStopIdState}`)
 					.then((response) => {
 						if (!response.ok) console.log(`Failed to fetch realtime data for stopId: ${dataActiveStopIdState}`);
 						else return response.json();
@@ -158,7 +157,7 @@ export const StopsDetailContextProvider = ({ children, stopId }: { children: Rea
 		fetchData();
 		const interval = setInterval(fetchData, 10000);
 		return () => clearInterval(interval);
-	}, [dataActiveStopIdState, debugContext.flags.is_debug_mode]);
+	}, [dataActiveStopIdState]);
 
 	/**
  	* Fetch pattern data for the selected stop.

--- a/apps/frontend/src/themes/_default/styles/variables.css
+++ b/apps/frontend/src/themes/_default/styles/variables.css
@@ -10,6 +10,7 @@
 	--color-lines-inter-regional: #BB3E96;
 	--color-lines-mar: #0C807E;
 	--color-lines-turistica: #FF6900;
+	--color-brand-go: #005adc;
 
 	/* * */
 	/* COLOR / DEBUG */

--- a/apps/frontend/src/themes/_default/styles/variables.css
+++ b/apps/frontend/src/themes/_default/styles/variables.css
@@ -15,8 +15,7 @@
 	/* COLOR / DEBUG */
 
 	--color-debug: #055252;
-	--color-go: #005adc;
-	
+
 	/* * */
 	/* COLOR / SYSTEM */
 

--- a/apps/frontend/src/utils/getArrivalsApiBaseUrl.ts
+++ b/apps/frontend/src/utils/getArrivalsApiBaseUrl.ts
@@ -1,7 +1,0 @@
-import { getPublicVariable } from '@carrismetropolitana/website-shared-settings';
-
-const DEBUG_ARRIVALS_API_URL = 'https://go.tmlmobilidade.pt/eta/api';
-
-export function getArrivalsApiBaseUrl(isDebugMode: boolean): string {
-	return isDebugMode ? DEBUG_ARRIVALS_API_URL : getPublicVariable('api_url');
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11955,20 +11955,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-what": {
 			"version": "4.1.16",
 			"resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
@@ -13501,67 +13487,6 @@
 				"node": ">=4.0.0"
 			}
 		},
-		"node_modules/mongoose/node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/mongoose/node_modules/gaxios": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-			"integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"extend": "^3.0.2",
-				"https-proxy-agent": "^5.0.0",
-				"is-stream": "^2.0.0",
-				"node-fetch": "^2.6.9"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/mongoose/node_modules/gcp-metadata": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-			"integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"gaxios": "^5.0.0",
-				"json-bigint": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/mongoose/node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/mongoose/node_modules/mongodb": {
 			"version": "6.16.0",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
@@ -13606,56 +13531,6 @@
 				"socks": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/mongoose/node_modules/node-fetch": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/mongoose/node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/mongoose/node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"license": "BSD-2-Clause",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/mongoose/node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/mpath": {
@@ -13880,17 +13755,6 @@
 				"@swc/helpers": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/next-intl/node_modules/@swc/helpers": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-			"integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.8.0"
 			}
 		},
 		"node_modules/next/node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11955,6 +11955,20 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-what": {
 			"version": "4.1.16",
 			"resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
@@ -13487,6 +13501,67 @@
 				"node": ">=4.0.0"
 			}
 		},
+		"node_modules/mongoose/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/mongoose/node_modules/gaxios": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+			"integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^5.0.0",
+				"is-stream": "^2.0.0",
+				"node-fetch": "^2.6.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mongoose/node_modules/gcp-metadata": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+			"integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"gaxios": "^5.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mongoose/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/mongoose/node_modules/mongodb": {
 			"version": "6.16.0",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
@@ -13531,6 +13606,56 @@
 				"socks": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/mongoose/node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/mongoose/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/mongoose/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/mongoose/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/mpath": {
@@ -13755,6 +13880,17 @@
 				"@swc/helpers": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/next-intl/node_modules/@swc/helpers": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+			"integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.8.0"
 			}
 		},
 		"node_modules/next/node_modules/postcss": {


### PR DESCRIPTION
### Description

Reverts the previous approach of swapping the arrivals API to GO when debug mode was enabled. Production realtime data always comes from the Carris Metropolitana API (`api_url`).

In debug mode, stop timetable rows now show the production ETA and a secondary GO ETA (from TML’s GO API) for the same trip, so both sources can be compared without affecting what regular users see.

### Changelog
- **Arrivals API:** Removed `getArrivalsApiBaseUrl`; lines and stops always fetch realtime arrivals from `api_url`.
- **Stops detail:** Added parallel polling of GO arrivals (`timetable_realtime_go`) every 10s.
- **NextArrivals:** Added optional `tripId` prop and `DebugGoArrival` sub-component; GO ETA renders only when debug mode is on and a matching trip exists.
- **Styling:** Renamed `--color-go` to `--color-brand-go`; removed debug-mode GO styling from line path arrival components.