### PR TITLE
Fix CICM backoffice review corrections

### DIFF
--- a/apps/backoffice/payload-types.ts
+++ b/apps/backoffice/payload-types.ts
@@ -232,10 +232,6 @@ export interface Article {
    */
   specialSeries?: (string | null) | SpecialSery;
   /**
-   * Opcional. Use quando este conteúdo fizer parte de uma parceria.
-   */
-  partnership?: (string | null) | Partnership;
-  /**
    * Tempo estimado de leitura em minutos.
    */
   readTime: number;
@@ -304,21 +300,6 @@ export interface SpecialSery {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "partnerships".
- */
-export interface Partnership {
-  id: string;
-  title: string;
-  /**
-   * URL única para esta parceria. Será gerada automaticamente do título se deixado em branco.
-   */
-  slug: string;
-  description?: string | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "case-studies".
  */
 export interface CaseStudy {
@@ -332,7 +313,7 @@ export interface CaseStudy {
    * Resumo curto do caso de estudo que aparece na listagem e no início da página.
    */
   description: string;
-  type: string | ContentType;
+  type: 'comunicacao' | 'tecnologia' | 'operacao' | 'sustentabilidade';
   /**
    * Tempo estimado de leitura em minutos.
    */
@@ -440,6 +421,21 @@ export interface News {
 export interface Topic {
   id: string;
   title: string;
+  description?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "partnerships".
+ */
+export interface Partnership {
+  id: string;
+  title: string;
+  /**
+   * URL única para esta parceria. Será gerada automaticamente do título se deixado em branco.
+   */
+  slug: string;
   description?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -660,10 +656,6 @@ export interface Video {
    */
   specialSeries?: (string | null) | SpecialSery;
   /**
-   * Opcional. Use quando este conteúdo fizer parte de uma parceria.
-   */
-  partnership?: (string | null) | Partnership;
-  /**
    * Tempo estimado de visualização em minutos.
    */
   readTime: number;
@@ -719,15 +711,11 @@ export interface Interview {
    */
   description: string;
   contentFormat: 'transcript' | 'audio';
-  type: string | ContentType;
+  type: 'comunicacao' | 'tecnologia' | 'operacao' | 'sustentabilidade';
   /**
    * Opcional. Use quando este conteúdo fizer parte de uma Série Especial.
    */
   specialSeries?: (string | null) | SpecialSery;
-  /**
-   * Opcional. Use quando este conteúdo fizer parte de uma parceria.
-   */
-  partnership?: (string | null) | Partnership;
   guest: {
     picture?: (string | null) | Media;
     name: string;
@@ -779,7 +767,7 @@ export interface Interview {
     [k: string]: unknown;
   } | null;
   /**
-   * Ficheiro PDF com a transcrição completa da entrevista.
+   * Ficheiro PDF com a entrevista escrita completa.
    */
   transcriptPdf?: (string | null) | Media;
   publishDate: string;
@@ -820,7 +808,7 @@ export interface Report {
   /**
    * Ficheiro PDF disponível para download na página do relatório.
    */
-  reportPdf: string | Media;
+  reportPdf?: (string | null) | Media;
   /**
    * Ano ou edição destacada no bloco principal do relatório.
    */
@@ -1043,7 +1031,6 @@ export interface ArticlesSelect<T extends boolean = true> {
   description?: T;
   type?: T;
   specialSeries?: T;
-  partnership?: T;
   readTime?: T;
   heroImage?: T;
   heroImageCaption?: T;
@@ -1349,7 +1336,6 @@ export interface VideosSelect<T extends boolean = true> {
       };
   type?: T;
   specialSeries?: T;
-  partnership?: T;
   readTime?: T;
   video?: T;
   content?: T;
@@ -1384,7 +1370,6 @@ export interface InterviewsSelect<T extends boolean = true> {
   contentFormat?: T;
   type?: T;
   specialSeries?: T;
-  partnership?: T;
   guest?:
     | T
     | {

--- a/apps/backoffice/src/app/public-api/articles/route.ts
+++ b/apps/backoffice/src/app/public-api/articles/route.ts
@@ -1,5 +1,6 @@
 import payloadConfig from '@/payload-config';
 import { getPublicHeaders } from '@/utils/get-public-headers';
+import { resolveSpecialSeriesFilter } from '@/utils/resolve-special-series-filter';
 import { getPayload, type Where } from 'payload';
 
 /* * */
@@ -13,12 +14,12 @@ export const GET = async (request: Request) => {
 	const { searchParams } = new URL(request.url);
 	const type = searchParams.get('type');
 	const specialSeries = searchParams.get('special-series');
-	const partnership = searchParams.get('partnership');
 	const limit = Number(searchParams.get('limit')) || 10;
 	const page = Number(searchParams.get('page')) || 1;
 	const expertArticle = JSON.parse(searchParams.get('expert-article') ?? 'false');
 
 	const payload = await getPayload({ config: payloadConfig });
+	const specialSeriesFilter = await resolveSpecialSeriesFilter(payload, specialSeries);
 
 	//
 	// B. Build the where clause, optionally filtering by type (mapped to the type field).
@@ -26,8 +27,7 @@ export const GET = async (request: Request) => {
 	const whereClause: Where = {
 		status: { equals: 'published' },
 		...(type && { type: { in: type } }),
-		...(specialSeries && { specialSeries: { equals: specialSeries } }),
-		...(partnership && { partnership: { equals: partnership } }),
+		...(specialSeriesFilter.length && { specialSeries: { in: specialSeriesFilter } }),
 		...(expertArticle && { 'author.expertAuthor': { equals: expertArticle } }),
 	};
 

--- a/apps/backoffice/src/app/public-api/case-studies/route.ts
+++ b/apps/backoffice/src/app/public-api/case-studies/route.ts
@@ -23,7 +23,7 @@ export const GET = async (request: Request) => {
 
 	const whereClause: Where = {
 		status: { equals: 'published' },
-		...(type && { type: { equals: type } }),
+		...(type && { type: { in: type } }),
 	};
 
 	//

--- a/apps/backoffice/src/app/public-api/interviews/route.ts
+++ b/apps/backoffice/src/app/public-api/interviews/route.ts
@@ -1,6 +1,7 @@
 import payloadConfig from '@/payload-config';
 import { getPublicHeaders } from '@/utils/get-public-headers';
 import { hydratePublicInterviewRelations } from '@/utils/hydrate-public-content-relations';
+import { resolveSpecialSeriesFilter } from '@/utils/resolve-special-series-filter';
 import { getPayload, type Where } from 'payload';
 
 /* * */
@@ -14,20 +15,19 @@ export const GET = async (request: Request) => {
 	const { searchParams } = new URL(request.url);
 	const type = searchParams.get('type');
 	const specialSeries = searchParams.get('special-series');
-	const partnership = searchParams.get('partnership');
 	const limit = Number(searchParams.get('limit')) || 10;
 	const page = Number(searchParams.get('page')) || 1;
 
 	const payload = await getPayload({ config: payloadConfig });
+	const specialSeriesFilter = await resolveSpecialSeriesFilter(payload, specialSeries);
 
 	//
 	// B. Build the where clause, optionally filtering by type.
 
 	const whereClause: Where = {
 		status: { equals: 'published' },
-		...(type && { type: { equals: type } }),
-		...(specialSeries && { specialSeries: { equals: specialSeries } }),
-		...(partnership && { partnership: { equals: partnership } }),
+		...(type && { type: { in: type } }),
+		...(specialSeriesFilter.length && { specialSeries: { in: specialSeriesFilter } }),
 	};
 
 	//

--- a/apps/backoffice/src/app/public-api/special-series/route.ts
+++ b/apps/backoffice/src/app/public-api/special-series/route.ts
@@ -1,0 +1,20 @@
+import payloadConfig from '@/payload-config';
+import { getPublicHeaders } from '@/utils/get-public-headers';
+import { getPayload } from 'payload';
+
+/* * */
+
+export const GET = async () => {
+	const payload = await getPayload({ config: payloadConfig });
+
+	const foundSpecialSeries = await payload.find({
+		collection: 'special-series',
+		depth: 0,
+		limit: 100,
+		sort: 'title',
+	});
+
+	return Response.json(foundSpecialSeries, {
+		headers: getPublicHeaders(300),
+	});
+};

--- a/apps/backoffice/src/app/public-api/videos/route.ts
+++ b/apps/backoffice/src/app/public-api/videos/route.ts
@@ -1,5 +1,6 @@
 import payloadConfig from '@/payload-config';
 import { getPublicHeaders } from '@/utils/get-public-headers';
+import { resolveSpecialSeriesFilter } from '@/utils/resolve-special-series-filter';
 import { getPayload, type Where } from 'payload';
 
 /* * */
@@ -13,12 +14,12 @@ export const GET = async (request: Request) => {
 	const { searchParams } = new URL(request.url);
 	const type = searchParams.get('type');
 	const specialSeries = searchParams.get('special-series');
-	const partnership = searchParams.get('partnership');
 	const limit = Number(searchParams.get('limit')) || 10;
 	const page = Number(searchParams.get('page')) || 1;
 	const expertAuthor = JSON.parse(searchParams.get('expert-author') ?? 'false');
 
 	const payload = await getPayload({ config: payloadConfig });
+	const specialSeriesFilter = await resolveSpecialSeriesFilter(payload, specialSeries);
 
 	//
 	// B. Build the where clause, optionally filtering by type (mapped to the type field).
@@ -26,8 +27,7 @@ export const GET = async (request: Request) => {
 	const whereClause: Where = {
 		status: { equals: 'published' },
 		...(type && { type: { in: type } }),
-		...(specialSeries && { specialSeries: { equals: specialSeries } }),
-		...(partnership && { partnership: { equals: partnership } }),
+		...(specialSeriesFilter.length && { specialSeries: { in: specialSeriesFilter } }),
 		...(expertAuthor && { 'author.expertAuthor': { equals: expertAuthor } }),
 	};
 

--- a/apps/backoffice/src/schemas/Articles/collection.ts
+++ b/apps/backoffice/src/schemas/Articles/collection.ts
@@ -2,7 +2,6 @@
 
 import type { CollectionConfig } from 'payload';
 
-import { partnershipField } from '@/fields/partnership';
 import { publishedAtField } from '@/fields/published-at';
 import { specialSeriesField } from '@/fields/special-series';
 import { subjectField } from '@/fields/subject';
@@ -61,7 +60,6 @@ export const Articles: CollectionConfig = {
 		},
 		subjectField,
 		specialSeriesField,
-		partnershipField,
 		{
 			admin: {
 				description: 'Tempo estimado de leitura em minutos.',

--- a/apps/backoffice/src/schemas/CaseStudies/collection.ts
+++ b/apps/backoffice/src/schemas/CaseStudies/collection.ts
@@ -2,8 +2,8 @@
 
 import type { CollectionConfig } from 'payload';
 
-import { contentTypeField } from '@/fields/content-type';
 import { publishedAtField } from '@/fields/published-at';
+import { subjectField } from '@/fields/subject';
 import { updatedAtField } from '@/fields/updated-at';
 import { slugify } from '@/utils/slugify';
 
@@ -65,7 +65,7 @@ export const CaseStudies: CollectionConfig = {
 			required: true,
 			type: 'textarea',
 		},
-		contentTypeField,
+		subjectField,
 		{
 			admin: {
 				description: 'Tempo estimado de leitura em minutos.',

--- a/apps/backoffice/src/schemas/ContentTypes/collection.ts
+++ b/apps/backoffice/src/schemas/ContentTypes/collection.ts
@@ -17,6 +17,7 @@ export const ContentTypes: CollectionConfig = {
 	admin: {
 		defaultColumns: ['title', 'slug', 'updatedAt'],
 		group: 'CICM',
+		hidden: true,
 		useAsTitle: 'title',
 	},
 

--- a/apps/backoffice/src/schemas/Interviews/collection.ts
+++ b/apps/backoffice/src/schemas/Interviews/collection.ts
@@ -2,10 +2,9 @@
 
 import type { CollectionConfig } from 'payload';
 
-import { contentTypeField } from '@/fields/content-type';
-import { partnershipField } from '@/fields/partnership';
 import { publishedAtField } from '@/fields/published-at';
 import { specialSeriesField } from '@/fields/special-series';
+import { subjectField } from '@/fields/subject';
 import { updatedAtField } from '@/fields/updated-at';
 import { slugify } from '@/utils/slugify';
 
@@ -71,24 +70,23 @@ export const Interviews: CollectionConfig = {
 				position: 'sidebar',
 			},
 			defaultValue: 'transcript',
-			label: 'Formato',
+			label: 'Tipo de entrevista',
 			name: 'contentFormat',
 			options: [
 				{
-					label: 'Transcrição',
+					label: 'Escrita',
 					value: 'transcript',
 				},
 				{
-					label: 'Áudio',
+					label: 'Audio',
 					value: 'audio',
 				},
 			],
 			required: true,
 			type: 'select',
 		},
-		contentTypeField,
+		subjectField,
 		specialSeriesField,
-		partnershipField,
 		{
 			fields: [
 				{
@@ -171,6 +169,24 @@ export const Interviews: CollectionConfig = {
 			admin: {
 				condition: (_, siblingData) => siblingData?.contentFormat === 'audio',
 				description: 'Ficheiro de áudio da entrevista (upload direto).',
+				position: 'sidebar',
+			},
+			filterOptions: {
+				mimeType: {
+					in: [
+						'audio/aac',
+						'audio/flac',
+						'audio/m4a',
+						'audio/mp3',
+						'audio/mp4',
+						'audio/mpeg',
+						'audio/ogg',
+						'audio/wav',
+						'audio/webm',
+						'audio/x-m4a',
+						'audio/x-wav',
+					],
+				},
 			},
 			label: 'Ficheiro de Áudio',
 			name: 'audioFile',
@@ -222,7 +238,7 @@ export const Interviews: CollectionConfig = {
 				position: 'sidebar',
 			},
 			defaultValue: 5,
-			label: 'Tempo de Leitura (min)',
+			label: 'Tempo de Leitura da Escrita (min)',
 			min: 1,
 			name: 'readTime',
 			type: 'number',
@@ -230,30 +246,30 @@ export const Interviews: CollectionConfig = {
 				const branchData = data as InterviewBranchData;
 				if (branchData.contentFormat !== 'transcript') return true;
 				if (value) return true;
-				return 'O tempo de leitura é obrigatório para entrevistas em transcrição.';
+				return 'O tempo de leitura é obrigatório para entrevistas escritas.';
 			},
 		},
 		{
 			admin: {
 				condition: (_, siblingData) => siblingData?.contentFormat === 'transcript',
 			},
-			label: 'Transcrição',
+			label: 'Escrita',
 			name: 'transcript',
 			type: 'richText',
 			validate: (value, { data }) => {
 				const branchData = data as InterviewBranchData;
 				if (branchData.contentFormat !== 'transcript') return true;
 				if (value) return true;
-				return 'A transcrição é obrigatória.';
+				return 'O conteúdo da entrevista escrita é obrigatório.';
 			},
 		},
 		{
 			admin: {
 				condition: (_, siblingData) => siblingData?.contentFormat === 'transcript',
-				description: 'Ficheiro PDF com a transcrição completa da entrevista.',
+				description: 'Ficheiro PDF com a entrevista escrita completa.',
 				position: 'sidebar',
 			},
-			label: 'PDF da Transcrição',
+			label: 'PDF da Escrita',
 			name: 'transcriptPdf',
 			relationTo: 'media',
 			type: 'upload',

--- a/apps/backoffice/src/schemas/Partnerships/collection.ts
+++ b/apps/backoffice/src/schemas/Partnerships/collection.ts
@@ -17,6 +17,7 @@ export const Partnerships: CollectionConfig = {
 	admin: {
 		defaultColumns: ['title', 'slug', 'updatedAt'],
 		group: 'CICM',
+		hidden: true,
 		useAsTitle: 'title',
 	},
 

--- a/apps/backoffice/src/schemas/Reports/collection.ts
+++ b/apps/backoffice/src/schemas/Reports/collection.ts
@@ -161,7 +161,6 @@ export const Reports: CollectionConfig = {
 			label: 'PDF do Relatório',
 			name: 'reportPdf',
 			relationTo: 'media',
-			required: true,
 			type: 'upload',
 		},
 		{

--- a/apps/backoffice/src/schemas/Videos/collection.ts
+++ b/apps/backoffice/src/schemas/Videos/collection.ts
@@ -2,7 +2,6 @@
 
 import type { CollectionConfig } from 'payload';
 
-import { partnershipField } from '@/fields/partnership';
 import { publishedAtField } from '@/fields/published-at';
 import { specialSeriesField } from '@/fields/special-series';
 import { subjectField } from '@/fields/subject';
@@ -138,7 +137,6 @@ export const Videos: CollectionConfig = {
 		},
 		subjectField,
 		specialSeriesField,
-		partnershipField,
 		{
 			admin: {
 				description: 'Tempo estimado de visualização em minutos.',

--- a/apps/backoffice/src/utils/hydrate-public-content-relations.ts
+++ b/apps/backoffice/src/utils/hydrate-public-content-relations.ts
@@ -1,6 +1,6 @@
 /* * */
 
-import type { CaseStudy, ContentType, Interview, Media } from '../../payload-types';
+import type { CaseStudy, Interview, Media } from '../../payload-types';
 import type { Payload } from 'payload';
 
 /* * */
@@ -8,21 +8,6 @@ import type { Payload } from 'payload';
 type MaybeRelation<T> = null | string | T | undefined;
 
 /* * */
-
-async function hydrateContentType(payload: Payload, value: MaybeRelation<ContentType>): Promise<MaybeRelation<ContentType>> {
-	if (typeof value !== 'string') return value;
-
-	try {
-		return await payload.findByID({
-			collection: 'content-types',
-			depth: 0,
-			id: value,
-		});
-	}
-	catch {
-		return value;
-	}
-}
 
 async function hydrateMedia(payload: Payload, value: MaybeRelation<Media>): Promise<MaybeRelation<Media>> {
 	if (typeof value !== 'string') return value;
@@ -42,8 +27,7 @@ async function hydrateMedia(payload: Payload, value: MaybeRelation<Media>): Prom
 /* * */
 
 export async function hydratePublicCaseStudyRelations(payload: Payload, caseStudy: CaseStudy): Promise<CaseStudy> {
-	const [type, heroImage, authorPicture, seoOgImage] = await Promise.all([
-		hydrateContentType(payload, caseStudy.type),
+	const [heroImage, authorPicture, seoOgImage] = await Promise.all([
 		hydrateMedia(payload, caseStudy.heroImage),
 		hydrateMedia(payload, caseStudy.author.picture),
 		hydrateMedia(payload, caseStudy.seo?.ogImage),
@@ -62,13 +46,11 @@ export async function hydratePublicCaseStudyRelations(payload: Payload, caseStud
 				ogImage: seoOgImage,
 			}
 			: caseStudy.seo,
-		type: type ?? caseStudy.type,
 	};
 }
 
 export async function hydratePublicInterviewRelations(payload: Payload, interview: Interview): Promise<Interview> {
-	const [type, guestPicture, hostPicture, audioFile, transcriptPdf, seoOgImage] = await Promise.all([
-		hydrateContentType(payload, interview.type),
+	const [guestPicture, hostPicture, audioFile, transcriptPdf, seoOgImage] = await Promise.all([
 		hydrateMedia(payload, interview.guest.picture),
 		hydrateMedia(payload, interview.host?.picture),
 		hydrateMedia(payload, interview.audioFile),
@@ -96,6 +78,5 @@ export async function hydratePublicInterviewRelations(payload: Payload, intervie
 			}
 			: interview.seo,
 		transcriptPdf,
-		type: type ?? interview.type,
 	};
 }

--- a/apps/backoffice/src/utils/resolve-special-series-filter.ts
+++ b/apps/backoffice/src/utils/resolve-special-series-filter.ts
@@ -1,0 +1,29 @@
+/* * */
+
+import type { Payload } from 'payload';
+
+/* * */
+
+export async function resolveSpecialSeriesFilter(payload: Payload, value: null | string): Promise<string[]> {
+	if (!value) return [];
+
+	const requestedValues = value
+		.split(',')
+		.map(item => item.trim())
+		.filter(Boolean);
+
+	if (!requestedValues.length) return [];
+
+	const foundSpecialSeries = await payload.find({
+		collection: 'special-series',
+		depth: 0,
+		limit: requestedValues.length,
+		where: {
+			slug: { in: requestedValues },
+		},
+	});
+
+	const idsBySlug = new Map(foundSpecialSeries.docs.map(item => [item.slug, item.id]));
+
+	return requestedValues.map(item => idsBySlug.get(item) ?? item);
+}


### PR DESCRIPTION
## Summary
- hides CICM-only deprecated admin collections from the Payload navigation and removes Partnerships from CICM content models
- makes report PDFs optional and restricts interview audio uploads to audio MIME types
- updates interview admin copy from Transcript to Written and keeps theme required for relevant CICM content
- adds the public Special Series API and filters public article/interview/video APIs by Special Series slugs
- regenerates Payload types

## Why
These changes support the CICM frontend corrections requested in the review PDF while keeping the official Carris website frontend untouched.

## Validation
- npm run generate:types --workspace=@carrismetropolitana/website-backoffice
- npm run lint --workspace=@carrismetropolitana/website-backoffice
- npm run build --workspace=@carrismetropolitana/website-backoffice
- local API validation for articles, interviews, videos, reports, and special-series

## Notes
- branch is based on upstream/staging and pushed from the Orion-Lab-Studio fork
- frontend changes are in the separate CICM PR